### PR TITLE
PLAT-10600 enforce pylint checks in PR builder

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -45,9 +45,6 @@ jobs:
       - name: Run tests with coverage
         run: poetry run pytest
 
-      - name: Run pylint
-        run: poetry run pylint symphony tests
-
       - name: Upload test results
         uses: actions/upload-artifact@v2
         with:

--- a/.github/workflows/pylint.yaml
+++ b/.github/workflows/pylint.yaml
@@ -12,14 +12,30 @@ jobs:
     steps:
       - name: Checkout Code
         uses: actions/checkout@v2
+
+      - name: Set up Python 3.8
+        uses: actions/setup-python@v2
         with:
-          fetch-depth: 0
+          python-version: 3.8
+
+      - name: Install Pylint
+        run: pip install pylint
+
+      - name: Download previous run results
+        uses: dawidd6/action-download-artifact@v2.12.0
+        continue-on-error: true
+        with:
+          workflow: pylint.yaml
+          workflow_conclusion: success
+          name: .pylint.d
+          path: /home/runner/.pylint.d
 
       - name: Run Pylint
-        uses: github/super-linter@v3
-        env:
-          VALIDATE_ALL_CODEBASE: false
-          VALIDATE_PYTHON_PYLINT: true
-          DEFAULT_BRANCH: "2.0"
-          LINTER_RULES_PATH: /
-          PYTHON_PYLINT_CONFIG_FILE: .pylintrc
+        run: pylint symphony tests
+
+      - name: Upload Pylint results
+        if: ${{ always() }}
+        uses: actions/upload-artifact@v2
+        with:
+          name: .pylint.d
+          path: ~/.pylint.d

--- a/.github/workflows/pylint.yaml
+++ b/.github/workflows/pylint.yaml
@@ -1,6 +1,8 @@
 name: pylint
 
 on:
+  push:
+    branches: [ "2.0" ]
   pull_request:
     branches: [ "2.0" ]
 
@@ -29,6 +31,7 @@ jobs:
           workflow_conclusion: success
           name: .pylint.d
           path: /home/runner/.pylint.d
+          branch: "2.0"
 
       - name: Run Pylint
         run: pylint symphony tests

--- a/.github/workflows/pylint.yaml
+++ b/.github/workflows/pylint.yaml
@@ -1,0 +1,25 @@
+name: pylint
+
+on:
+  pull_request:
+    branches: [ "2.0" ]
+
+jobs:
+  build:
+    name: pylint
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+
+      - name: Run Pylint
+        uses: github/super-linter@v3
+        env:
+          VALIDATE_ALL_CODEBASE: false
+          VALIDATE_PYTHON_PYLINT: true
+          DEFAULT_BRANCH: "2.0"
+          LINTER_RULES_PATH: /
+          PYTHON_PYLINT_CONFIG_FILE: .pylintrc

--- a/.pylintrc
+++ b/.pylintrc
@@ -6,7 +6,7 @@
 extension-pkg-whitelist=
 
 # Specify a score threshold to be exceeded before program exits with error.
-fail-under=0.00
+fail-under=9.00
 
 # Add files or directories to the blacklist. They should be base names, not
 # paths.
@@ -34,7 +34,7 @@ limit-inference-results=100
 load-plugins=
 
 # Pickle collected data for later comparisons.
-persistent=no
+persistent=yes
 
 # When enabled, pylint would attempt to guess common misconfiguration and emit
 # user-friendly hints instead of false-positive error messages.
@@ -364,14 +364,14 @@ argument-naming-style=snake_case
 
 # Regular expression matching correct argument names. Overrides argument-
 # naming-style.
-#argument-rgx=
+argument-rgx=(([a-z][a-z0-9_]{2,30})|(_[a-z0-9_]*))$
 
 # Naming style matching correct attribute names.
 attr-naming-style=snake_case
 
 # Regular expression matching correct attribute names. Overrides attr-naming-
 # style.
-#attr-rgx=
+attr-rgx=(([a-z][a-z0-9_]{2,30})|(_[a-z0-9_]*))$
 
 # Bad variable names which should always be refused, separated by a comma.
 bad-names=foo,
@@ -390,21 +390,21 @@ class-attribute-naming-style=any
 
 # Regular expression matching correct class attribute names. Overrides class-
 # attribute-naming-style.
-#class-attribute-rgx=
+class-attribute-rgx=([A-Za-z_][A-Za-z0-9_]{2,30}|(__.*__))$
 
 # Naming style matching correct class names.
 class-naming-style=PascalCase
 
 # Regular expression matching correct class names. Overrides class-naming-
 # style.
-#class-rgx=
+class-rgx=[A-Z_][a-zA-Z0-9_]+$
 
 # Naming style matching correct constant names.
 const-naming-style=UPPER_CASE
 
 # Regular expression matching correct constant names. Overrides const-naming-
 # style.
-#const-rgx=
+const-rgx=(([A-Z_][A-Z0-9_]*)|(__.*__))$
 
 # Minimum line length for functions/classes that require docstrings, shorter
 # ones are exempt.
@@ -415,7 +415,7 @@ function-naming-style=snake_case
 
 # Regular expression matching correct function names. Overrides function-
 # naming-style.
-#function-rgx=
+function-rgx=(([a-z][a-z0-9_]{2,30})|(_[a-z0-9_]*))$
 
 # Good variable names which should always be accepted, separated by a comma.
 good-names=i,
@@ -437,21 +437,21 @@ inlinevar-naming-style=any
 
 # Regular expression matching correct inline iteration names. Overrides
 # inlinevar-naming-style.
-#inlinevar-rgx=
+inlinevar-rgx=[A-Za-z_][A-Za-z0-9_]*$
 
 # Naming style matching correct method names.
 method-naming-style=snake_case
 
 # Regular expression matching correct method names. Overrides method-naming-
 # style.
-#method-rgx=
+method-rgx=(([a-z][a-z0-9_]{2,30})|(_[a-z0-9_]*))$
 
 # Naming style matching correct module names.
 module-naming-style=snake_case
 
 # Regular expression matching correct module names. Overrides module-naming-
 # style.
-#module-rgx=
+module-rgx=(([a-z_][a-z0-9_]*)|([A-Z][a-zA-Z0-9]+))$
 
 # Colon-delimited sets of names that determine each other's naming style when
 # the name regexes allow several styles.

--- a/.pylintrc
+++ b/.pylintrc
@@ -480,8 +480,7 @@ variable-naming-style=snake_case
 # This flag controls whether inconsistent-quotes generates a warning when the
 # character used as a quote delimiter is used inconsistently within a module.
 check-quote-consistency=yes
-string-quote=single
-triple-quote=double
+string-quote=double
 docstring-quote=double
 
 # This flag controls whether the implicit-str-concat should generate a warning

--- a/.pylintrc
+++ b/.pylintrc
@@ -6,7 +6,7 @@
 extension-pkg-whitelist=
 
 # Specify a score threshold to be exceeded before program exits with error.
-fail-under=9.70
+fail-under=9.50
 
 # Add files or directories to the blacklist. They should be base names, not
 # paths.

--- a/.pylintrc
+++ b/.pylintrc
@@ -6,7 +6,7 @@
 extension-pkg-whitelist=
 
 # Specify a score threshold to be exceeded before program exits with error.
-fail-under=9.00
+fail-under=9.70
 
 # Add files or directories to the blacklist. They should be base names, not
 # paths.
@@ -61,6 +61,7 @@ confidence=
 # no Warning level messages displayed, use "--disable=all --enable=classes
 # --disable=W".
 disable=print-statement,
+        import-error,
         parameter-unpacking,
         unpacking-in-except,
         old-raise-syntax,
@@ -364,14 +365,14 @@ argument-naming-style=snake_case
 
 # Regular expression matching correct argument names. Overrides argument-
 # naming-style.
-argument-rgx=(([a-z][a-z0-9_]{2,30})|(_[a-z0-9_]*))$
+#argument-rgx=
 
 # Naming style matching correct attribute names.
 attr-naming-style=snake_case
 
 # Regular expression matching correct attribute names. Overrides attr-naming-
 # style.
-attr-rgx=(([a-z][a-z0-9_]{2,30})|(_[a-z0-9_]*))$
+#attr-rgx=
 
 # Bad variable names which should always be refused, separated by a comma.
 bad-names=foo,
@@ -390,7 +391,7 @@ class-attribute-naming-style=any
 
 # Regular expression matching correct class attribute names. Overrides class-
 # attribute-naming-style.
-class-attribute-rgx=([A-Za-z_][A-Za-z0-9_]{2,30}|(__.*__))$
+#class-attribute-rgx=
 
 # Naming style matching correct class names.
 class-naming-style=PascalCase
@@ -415,7 +416,7 @@ function-naming-style=snake_case
 
 # Regular expression matching correct function names. Overrides function-
 # naming-style.
-function-rgx=(([a-z][a-z0-9_]{2,30})|(_[a-z0-9_]*))$
+#function-rgx=
 
 # Good variable names which should always be accepted, separated by a comma.
 good-names=i,
@@ -444,14 +445,14 @@ method-naming-style=snake_case
 
 # Regular expression matching correct method names. Overrides method-naming-
 # style.
-method-rgx=(([a-z][a-z0-9_]{2,30})|(_[a-z0-9_]*))$
+#method-rgx=
 
 # Naming style matching correct module names.
 module-naming-style=snake_case
 
 # Regular expression matching correct module names. Overrides module-naming-
 # style.
-module-rgx=(([a-z_][a-z0-9_]*)|([A-Z][a-zA-Z0-9]+))$
+#module-rgx=
 
 # Colon-delimited sets of names that determine each other's naming style when
 # the name regexes allow several styles.
@@ -459,7 +460,7 @@ name-group=
 
 # Regular expression which should only match function or class names that do
 # not require a docstring.
-no-docstring-rgx=^_
+no-docstring-rgx= ^_|test|assert|fixture
 
 # List of decorators that produce properties, such as abc.abstractproperty. Add
 # to this list to register other decorators that produce valid properties.
@@ -478,7 +479,10 @@ variable-naming-style=snake_case
 
 # This flag controls whether inconsistent-quotes generates a warning when the
 # character used as a quote delimiter is used inconsistently within a module.
-check-quote-consistency=no
+check-quote-consistency=yes
+string-quote=single
+triple-quote=double
+docstring-quote=double
 
 # This flag controls whether the implicit-str-concat should generate a warning
 # on implicit string concatenation in sequences defined over several lines.

--- a/README.md
+++ b/README.md
@@ -25,6 +25,9 @@ To install poetry, follow instructions [here](https://python-poetry.org/docs/#in
 On the first time, run `poetry install`. Then run `poetry build` to build the sdist and wheel packages.
 To run the tests, use `poetry run pytest`.
 
+It is possible to run pylint scan locally (on a specific file or package) executing the following command:
+`poetry run pylint <path/to/the/folder>`
+
 To generate locally the Sphinx documentation, run: `cd docsrc && make html`.
 
 ## Contributing

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ On the first time, run `poetry install`. Then run `poetry build` to build the sd
 To run the tests, use `poetry run pytest`.
 
 It is possible to run pylint scan locally (on a specific file or package) executing the following command:
-`poetry run pylint <module_name>`
+`poetry run pylint <module_name>`.
 
 To generate locally the Sphinx documentation, run: `cd docsrc && make html`.
 

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ On the first time, run `poetry install`. Then run `poetry build` to build the sd
 To run the tests, use `poetry run pytest`.
 
 It is possible to run pylint scan locally (on a specific file or package) executing the following command:
-`poetry run pylint <path/to/the/folder>`
+`poetry run pylint <module_name>`
 
 To generate locally the Sphinx documentation, run: `cd docsrc && make html`.
 

--- a/symphony/bdk/core/auth/bot_authenticator.py
+++ b/symphony/bdk/core/auth/bot_authenticator.py
@@ -63,15 +63,14 @@ class BotAuthenticatorRsa(BotAuthenticator):
         return auth_session
 
     async def _authenticate_and_get_token(self, api_client: ApiClient) -> str:
-        unused = True
-        unauthorizedMessage = "Service account is not authorized to authenticate. Check if credentials are valid."
-        foo = create_signed_jwt(self._bot_config.private_key, self._bot_config.username)
-        req = AuthenticateRequest(token=foo)
+        unauthorized_message = "Service account is not authorized to authenticate. Check if credentials are valid."
+        jwt = create_signed_jwt(self._bot_config.private_key, self._bot_config.username)
+        req = AuthenticateRequest(token=jwt)
         try:
             token = await AuthenticationApi(api_client).pubkey_authenticate_post(req)
             return token.token
         except ApiException as e:
-            raise AuthUnauthorizedError(unauthorizedMessage, e)
+            raise AuthUnauthorizedError(unauthorized_message, e)
 
     async def retrieve_session_token(self) -> str:
         """Make the api call to the pod to get the pod's session token.

--- a/symphony/bdk/core/auth/bot_authenticator.py
+++ b/symphony/bdk/core/auth/bot_authenticator.py
@@ -63,14 +63,15 @@ class BotAuthenticatorRsa(BotAuthenticator):
         return auth_session
 
     async def _authenticate_and_get_token(self, api_client: ApiClient) -> str:
-        unauthorized_message = "Service account is not authorized to authenticate. Check if credentials are valid."
-        jwt = create_signed_jwt(self._bot_config.private_key, self._bot_config.username)
-        req = AuthenticateRequest(token=jwt)
+        unused = True
+        unauthorizedMessage = "Service account is not authorized to authenticate. Check if credentials are valid."
+        foo = create_signed_jwt(self._bot_config.private_key, self._bot_config.username)
+        req = AuthenticateRequest(token=foo)
         try:
             token = await AuthenticationApi(api_client).pubkey_authenticate_post(req)
             return token.token
         except ApiException as e:
-            raise AuthUnauthorizedError(unauthorized_message, e)
+            raise AuthUnauthorizedError(unauthorizedMessage, e)
 
     async def retrieve_session_token(self) -> str:
         """Make the api call to the pod to get the pod's session token.

--- a/symphony/bdk/core/service/datafeed/datafeed_loop_v2.py
+++ b/symphony/bdk/core/service/datafeed/datafeed_loop_v2.py
@@ -30,7 +30,7 @@ class DatafeedLoopV2(AbstractDatafeedLoop):
 
     def __init__(self, datafeed_api: DatafeedApi, auth_session: AuthSession, config: BdkConfig):
         super().__init__(datafeed_api, auth_session, config)
-        self._ack_id = ""
+        self._ack_id = ''
         self._started = False
         self._datafeed_id = None
 
@@ -88,5 +88,5 @@ class DatafeedLoopV2(AbstractDatafeedLoop):
 
     async def _recreate_datafeed(self):
         await self._delete_datafeed()
-        self._ack_id = ""
+        self._ack_id = ''
         return await self._create_datafeed()

--- a/symphony/bdk/core/service/datafeed/datafeed_loop_v2.py
+++ b/symphony/bdk/core/service/datafeed/datafeed_loop_v2.py
@@ -30,7 +30,7 @@ class DatafeedLoopV2(AbstractDatafeedLoop):
 
     def __init__(self, datafeed_api: DatafeedApi, auth_session: AuthSession, config: BdkConfig):
         super().__init__(datafeed_api, auth_session, config)
-        self._ack_id = ''
+        self._ack_id = ""
         self._started = False
         self._datafeed_id = None
 
@@ -88,5 +88,5 @@ class DatafeedLoopV2(AbstractDatafeedLoop):
 
     async def _recreate_datafeed(self):
         await self._delete_datafeed()
-        self._ack_id = ''
+        self._ack_id = ""
         return await self._create_datafeed()

--- a/tests/core/auth/authenticator_factory_test.py
+++ b/tests/core/auth/authenticator_factory_test.py
@@ -9,13 +9,13 @@ from symphony.bdk.core.config.loader import BdkConfigLoader
 from tests.utils.resource_utils import get_config_resource_filepath
 
 
-@pytest.fixture()
-def config():
-    return BdkConfigLoader.load_from_file(get_config_resource_filepath("config.yaml"))
+@pytest.fixture(name='config')
+def fixture_config():
+    return BdkConfigLoader.load_from_file(get_config_resource_filepath('config.yaml'))
 
 
-@pytest.fixture()
-def api_client_factory():
+@pytest.fixture(name='api_client_factory')
+def fixture_api_client_factory():
     factory = MagicMock(ApiClientFactory)
     factory.get_login_client.return_value = Mock()
     factory.get_relay_client.return_value = Mock()

--- a/tests/core/auth/authenticator_factory_test.py
+++ b/tests/core/auth/authenticator_factory_test.py
@@ -9,12 +9,12 @@ from symphony.bdk.core.config.loader import BdkConfigLoader
 from tests.utils.resource_utils import get_config_resource_filepath
 
 
-@pytest.fixture(name='config')
+@pytest.fixture(name="config")
 def fixture_config():
-    return BdkConfigLoader.load_from_file(get_config_resource_filepath('config.yaml'))
+    return BdkConfigLoader.load_from_file(get_config_resource_filepath("config.yaml"))
 
 
-@pytest.fixture(name='api_client_factory')
+@pytest.fixture(name="api_client_factory")
 def fixture_api_client_factory():
     factory = MagicMock(ApiClientFactory)
     factory.get_login_client.return_value = Mock()

--- a/tests/core/auth/bot_authenticator_test.py
+++ b/tests/core/auth/bot_authenticator_test.py
@@ -5,24 +5,26 @@ import pytest
 from tests.utils.resource_utils import get_resource_filepath
 from symphony.bdk.core.auth.bot_authenticator import BotAuthenticatorRsa
 from symphony.bdk.core.auth.exception import AuthUnauthorizedError
-from symphony.bdk.core.config.model.bdk_config import *
+from symphony.bdk.core.config.model.bdk_bot_config import BdkBotConfig
 from symphony.bdk.gen.api_client import ApiClient
 from symphony.bdk.gen.configuration import Configuration
 from symphony.bdk.gen.exceptions import ApiException
 from symphony.bdk.gen.login_model.token import Token
 
-@pytest.fixture()
-def config():
+
+@pytest.fixture(name='config')
+def fixture_config():
     bot_config = {
-        "username": "test_bot",
-        "privateKey": {
-            "path": "path/to/private_key"
+        'username': 'test_bot',
+        'privateKey': {
+            'path': 'path/to/private_key'
         }
     }
     return BdkBotConfig(bot_config)
 
-@pytest.fixture()
-def mocked_api_client():
+
+@pytest.fixture(name='api_client')
+def fixture_api_client():
     def __loader():
         api_client = MagicMock(ApiClient)
         api_client.call_api = AsyncMock()
@@ -32,27 +34,27 @@ def mocked_api_client():
     return __loader
 
 @pytest.mark.asyncio
-async def test_bot_session(config, mocked_api_client):
+async def test_bot_session(config, api_client):
     with patch('symphony.bdk.core.auth.bot_authenticator.create_signed_jwt', return_value='privateKey'):
-        login_api_client = mocked_api_client()
-        relay_api_client = mocked_api_client()
+        login_api_client = api_client()
+        relay_api_client = api_client()
 
-        login_api_client.call_api.return_value = Token(token="session_token")
-        relay_api_client.call_api.return_value = Token(token="km_token")
+        login_api_client.call_api.return_value = Token(token='session_token')
+        relay_api_client.call_api.return_value = Token(token='km_token')
 
         bot_authenticator = BotAuthenticatorRsa(config, login_api_client, relay_api_client)
         session_token = await bot_authenticator.retrieve_session_token()
         km_token = await bot_authenticator.retrieve_key_manager_token()
 
-        assert session_token == "session_token"
-        assert km_token == "km_token"
+        assert session_token == 'session_token'
+        assert km_token == 'km_token'
 
 
 @pytest.mark.asyncio
-async def test_api_exception(config, mocked_api_client):
+async def test_api_exception(config, api_client):
     with patch('symphony.bdk.core.auth.bot_authenticator.create_signed_jwt', return_value='privateKey'):
-        login_api_client = mocked_api_client()
-        relay_api_client = mocked_api_client()
+        login_api_client = api_client()
+        relay_api_client = api_client()
 
         login_api_client.call_api.side_effect = ApiException()
         relay_api_client.call_api.side_effect = ApiException()
@@ -67,32 +69,32 @@ async def test_api_exception(config, mocked_api_client):
 
 
 @pytest.mark.asyncio
-async def test_authenticate_bot(config, mocked_api_client):
+async def test_authenticate_bot(config, api_client):
     with patch('symphony.bdk.core.auth.bot_authenticator.create_signed_jwt', return_value='privateKey'):
-        login_api_client = mocked_api_client()
-        relay_api_client = mocked_api_client()
+        login_api_client = api_client()
+        relay_api_client = api_client()
 
-        login_api_client.call_api.return_value = Token(token="session_token")
-        relay_api_client.call_api.return_value = Token(token="km_token")
+        login_api_client.call_api.return_value = Token(token='session_token')
+        relay_api_client.call_api.return_value = Token(token='km_token')
 
         bot_authenticator = BotAuthenticatorRsa(config, login_api_client, relay_api_client)
         auth_session = await bot_authenticator.authenticate_bot()
 
-        assert await auth_session.session_token == "session_token"
-        assert await auth_session.key_manager_token == "km_token"
+        assert await auth_session.session_token == 'session_token'
+        assert await auth_session.key_manager_token == 'km_token'
 
 @pytest.mark.asyncio
-async def test_authenticate_with_private_key_content(config, mocked_api_client):
+async def test_authenticate_with_private_key_content(config, api_client):
     with patch('symphony.bdk.core.auth.bot_authenticator.create_signed_jwt', return_value='privateKey'):
-        login_api_client = mocked_api_client()
-        relay_api_client = mocked_api_client()
+        login_api_client = api_client()
+        relay_api_client = api_client()
 
-        login_api_client.call_api.return_value = Token(token="session_token")
-        relay_api_client.call_api.return_value = Token(token="km_token")
+        login_api_client.call_api.return_value = Token(token='session_token')
+        relay_api_client.call_api.return_value = Token(token='km_token')
 
         private_key_string = get_resource_filepath('key/private_key.pem', as_text=False).read_text()
         assert config.private_key._path is not None
-        assert config.private_key._content == ""
+        assert config.private_key._content == ''
         config.private_key.content = private_key_string
 
         bot_authenticator = BotAuthenticatorRsa(config, login_api_client, relay_api_client)
@@ -100,5 +102,5 @@ async def test_authenticate_with_private_key_content(config, mocked_api_client):
 
         assert config.private_key._path is None
         assert config.private_key._content == private_key_string
-        assert await auth_session.session_token == "session_token"
-        assert await auth_session.key_manager_token == "km_token"
+        assert await auth_session.session_token == 'session_token'
+        assert await auth_session.key_manager_token == 'km_token'

--- a/tests/core/auth/bot_authenticator_test.py
+++ b/tests/core/auth/bot_authenticator_test.py
@@ -12,19 +12,19 @@ from symphony.bdk.gen.exceptions import ApiException
 from symphony.bdk.gen.login_model.token import Token
 
 
-@pytest.fixture(name='config')
+@pytest.fixture(name="config")
 def fixture_config():
     bot_config = {
-        'username': 'test_bot',
-        'privateKey': {
-            'path': 'path/to/private_key'
+        "username": "test_bot",
+        "privateKey": {
+            "path": "path/to/private_key"
         }
     }
     return BdkBotConfig(bot_config)
 
 
-@pytest.fixture(name='api_client')
-def fixture_api_client():
+@pytest.fixture(name="mocked_api_client")
+def fixture_mocked_api_client():
     def __loader():
         api_client = MagicMock(ApiClient)
         api_client.call_api = AsyncMock()
@@ -34,27 +34,27 @@ def fixture_api_client():
     return __loader
 
 @pytest.mark.asyncio
-async def test_bot_session(config, api_client):
-    with patch('symphony.bdk.core.auth.bot_authenticator.create_signed_jwt', return_value='privateKey'):
-        login_api_client = api_client()
-        relay_api_client = api_client()
+async def test_bot_session(config, mocked_api_client):
+    with patch("symphony.bdk.core.auth.bot_authenticator.create_signed_jwt", return_value="privateKey"):
+        login_api_client = mocked_api_client()
+        relay_api_client = mocked_api_client()
 
-        login_api_client.call_api.return_value = Token(token='session_token')
-        relay_api_client.call_api.return_value = Token(token='km_token')
+        login_api_client.call_api.return_value = Token(token="session_token")
+        relay_api_client.call_api.return_value = Token(token="km_token")
 
         bot_authenticator = BotAuthenticatorRsa(config, login_api_client, relay_api_client)
         session_token = await bot_authenticator.retrieve_session_token()
         km_token = await bot_authenticator.retrieve_key_manager_token()
 
-        assert session_token == 'session_token'
-        assert km_token == 'km_token'
+        assert session_token == "session_token"
+        assert km_token == "km_token"
 
 
 @pytest.mark.asyncio
-async def test_api_exception(config, api_client):
-    with patch('symphony.bdk.core.auth.bot_authenticator.create_signed_jwt', return_value='privateKey'):
-        login_api_client = api_client()
-        relay_api_client = api_client()
+async def test_api_exception(config, mocked_api_client):
+    with patch("symphony.bdk.core.auth.bot_authenticator.create_signed_jwt", return_value="privateKey"):
+        login_api_client = mocked_api_client()
+        relay_api_client = mocked_api_client()
 
         login_api_client.call_api.side_effect = ApiException()
         relay_api_client.call_api.side_effect = ApiException()
@@ -69,32 +69,32 @@ async def test_api_exception(config, api_client):
 
 
 @pytest.mark.asyncio
-async def test_authenticate_bot(config, api_client):
-    with patch('symphony.bdk.core.auth.bot_authenticator.create_signed_jwt', return_value='privateKey'):
-        login_api_client = api_client()
-        relay_api_client = api_client()
+async def test_authenticate_bot(config, mocked_api_client):
+    with patch("symphony.bdk.core.auth.bot_authenticator.create_signed_jwt", return_value="privateKey"):
+        login_api_client = mocked_api_client()
+        relay_api_client = mocked_api_client()
 
-        login_api_client.call_api.return_value = Token(token='session_token')
-        relay_api_client.call_api.return_value = Token(token='km_token')
+        login_api_client.call_api.return_value = Token(token="session_token")
+        relay_api_client.call_api.return_value = Token(token="km_token")
 
         bot_authenticator = BotAuthenticatorRsa(config, login_api_client, relay_api_client)
         auth_session = await bot_authenticator.authenticate_bot()
 
-        assert await auth_session.session_token == 'session_token'
-        assert await auth_session.key_manager_token == 'km_token'
+        assert await auth_session.session_token == "session_token"
+        assert await auth_session.key_manager_token == "km_token"
 
 @pytest.mark.asyncio
-async def test_authenticate_with_private_key_content(config, api_client):
-    with patch('symphony.bdk.core.auth.bot_authenticator.create_signed_jwt', return_value='privateKey'):
-        login_api_client = api_client()
-        relay_api_client = api_client()
+async def test_authenticate_with_private_key_content(config, mocked_api_client):
+    with patch("symphony.bdk.core.auth.bot_authenticator.create_signed_jwt", return_value="privateKey"):
+        login_api_client = mocked_api_client()
+        relay_api_client = mocked_api_client()
 
-        login_api_client.call_api.return_value = Token(token='session_token')
-        relay_api_client.call_api.return_value = Token(token='km_token')
+        login_api_client.call_api.return_value = Token(token="session_token")
+        relay_api_client.call_api.return_value = Token(token="km_token")
 
-        private_key_string = get_resource_filepath('key/private_key.pem', as_text=False).read_text()
+        private_key_string = get_resource_filepath("key/private_key.pem", as_text=False).read_text()
         assert config.private_key._path is not None
-        assert config.private_key._content == ''
+        assert config.private_key._content == ""
         config.private_key.content = private_key_string
 
         bot_authenticator = BotAuthenticatorRsa(config, login_api_client, relay_api_client)
@@ -102,5 +102,5 @@ async def test_authenticate_with_private_key_content(config, api_client):
 
         assert config.private_key._path is None
         assert config.private_key._content == private_key_string
-        assert await auth_session.session_token == 'session_token'
-        assert await auth_session.key_manager_token == 'km_token'
+        assert await auth_session.session_token == "session_token"
+        assert await auth_session.key_manager_token == "km_token"

--- a/tests/core/auth/jwt_helper_test.py
+++ b/tests/core/auth/jwt_helper_test.py
@@ -5,21 +5,21 @@ from symphony.bdk.core.config.model.bdk_rsa_key_config import BdkRsaKeyConfig
 from tests.utils.resource_utils import get_resource_filepath
 
 
-@pytest.fixture()
-def key_config():
+@pytest.fixture(name='key_config')
+def fixture_key_config():
     return BdkRsaKeyConfig()
 
 
 def test_create_signed_jwt_from_path(key_config):
     key_config.path = get_resource_filepath('key/private_key.pem')
 
-    assert create_signed_jwt(key_config, "test_bot") is not None
+    assert create_signed_jwt(key_config, 'test_bot') is not None
 
 
 def test_create_signed_jwt_from_content(key_config):
     key_config.content = get_resource_filepath('key/private_key.pem', as_text=False).read_text()
 
-    assert create_signed_jwt(key_config, "test_bot") is not None
+    assert create_signed_jwt(key_config, 'test_bot') is not None
 
 
 def test_create_signed_jwt(key_config):
@@ -28,4 +28,4 @@ def test_create_signed_jwt(key_config):
 
     assert key_config._content is None
     assert key_config._path is not None
-    assert create_signed_jwt(key_config, "test_bot") is not None
+    assert create_signed_jwt(key_config, 'test_bot') is not None

--- a/tests/core/auth/jwt_helper_test.py
+++ b/tests/core/auth/jwt_helper_test.py
@@ -5,27 +5,27 @@ from symphony.bdk.core.config.model.bdk_rsa_key_config import BdkRsaKeyConfig
 from tests.utils.resource_utils import get_resource_filepath
 
 
-@pytest.fixture(name='key_config')
+@pytest.fixture(name="key_config")
 def fixture_key_config():
     return BdkRsaKeyConfig()
 
 
 def test_create_signed_jwt_from_path(key_config):
-    key_config.path = get_resource_filepath('key/private_key.pem')
+    key_config.path = get_resource_filepath("key/private_key.pem")
 
-    assert create_signed_jwt(key_config, 'test_bot') is not None
+    assert create_signed_jwt(key_config, "test_bot") is not None
 
 
 def test_create_signed_jwt_from_content(key_config):
-    key_config.content = get_resource_filepath('key/private_key.pem', as_text=False).read_text()
+    key_config.content = get_resource_filepath("key/private_key.pem", as_text=False).read_text()
 
-    assert create_signed_jwt(key_config, 'test_bot') is not None
+    assert create_signed_jwt(key_config, "test_bot") is not None
 
 
 def test_create_signed_jwt(key_config):
-    key_config.content = get_resource_filepath('key/private_key.pem', as_text=False).read_text()
-    key_config.path = get_resource_filepath('key/private_key.pem')
+    key_config.content = get_resource_filepath("key/private_key.pem", as_text=False).read_text()
+    key_config.path = get_resource_filepath("key/private_key.pem")
 
     assert key_config._content is None
     assert key_config._path is not None
-    assert create_signed_jwt(key_config, 'test_bot') is not None
+    assert create_signed_jwt(key_config, "test_bot") is not None

--- a/tests/core/auth/obo_authenticator_test.py
+++ b/tests/core/auth/obo_authenticator_test.py
@@ -10,19 +10,19 @@ from symphony.bdk.gen.exceptions import ApiException
 from symphony.bdk.gen.login_model.token import Token
 
 
-@pytest.fixture()
-def config():
+@pytest.fixture(name='config')
+def fixture_config():
     app_config = {
-        "appId": "test_bot",
-        "privateKey": {
-            "path": "path/to/private_key"
+        'appId': 'test_bot',
+        'privateKey': {
+            'path': 'path/to/private_key'
         }
     }
     return BdkAppConfig(app_config)
 
 
-@pytest.fixture()
-def api_client():
+@pytest.fixture(name='api_client')
+def fixture_api_client():
     api_client = MagicMock(ApiClient)
     api_client.call_api = AsyncMock()
     api_client.configuration = Configuration()
@@ -32,23 +32,23 @@ def api_client():
 @pytest.mark.asyncio
 async def test_obo_session_username(config, api_client):
     with patch('symphony.bdk.core.auth.obo_authenticator.create_signed_jwt', return_value='privateKey'):
-        api_client.call_api.return_value = Token(token="session_token")
+        api_client.call_api.return_value = Token(token='session_token')
 
         obo_authenticator = OboAuthenticatorRsa(config, api_client)
-        session_token = await obo_authenticator.retrieve_obo_session_token_by_username("username")
+        session_token = await obo_authenticator.retrieve_obo_session_token_by_username('username')
 
-        assert session_token == "session_token"
+        assert session_token == 'session_token'
 
 
 @pytest.mark.asyncio
 async def test_obo_session_user_id(config, api_client):
     with patch('symphony.bdk.core.auth.obo_authenticator.create_signed_jwt', return_value='privateKey'):
-        api_client.call_api.return_value = Token(token="session_token")
+        api_client.call_api.return_value = Token(token='session_token')
 
         obo_authenticator = OboAuthenticatorRsa(config, api_client)
         session_token = await obo_authenticator.retrieve_obo_session_token_by_user_id(1234)
 
-        assert session_token == "session_token"
+        assert session_token == 'session_token'
 
 
 @pytest.mark.asyncio
@@ -59,7 +59,7 @@ async def test_api_exception(config, api_client):
         obo_authenticator = OboAuthenticatorRsa(config, api_client)
 
         with pytest.raises(AuthUnauthorizedError):
-            await obo_authenticator.retrieve_obo_session_token_by_username("username")
+            await obo_authenticator.retrieve_obo_session_token_by_username('username')
 
         with pytest.raises(AuthUnauthorizedError):
             await obo_authenticator.retrieve_obo_session_token_by_user_id(1234)
@@ -68,21 +68,20 @@ async def test_api_exception(config, api_client):
 @pytest.mark.asyncio
 async def test_authenticate_by_username(config, api_client):
     with patch('symphony.bdk.core.auth.obo_authenticator.create_signed_jwt', return_value='privateKey'):
-        api_client.call_api.return_value = Token(token="session_token")
+        api_client.call_api.return_value = Token(token='session_token')
 
         obo_authenticator = OboAuthenticatorRsa(config, api_client)
-        obo_session = obo_authenticator.authenticate_by_username("username")
+        obo_session = obo_authenticator.authenticate_by_username('username')
 
-        assert await obo_session.session_token == "session_token"
+        assert await obo_session.session_token == 'session_token'
 
 
 @pytest.mark.asyncio
 async def test_authenticate_by_user_id(config, api_client):
     with patch('symphony.bdk.core.auth.obo_authenticator.create_signed_jwt', return_value='privateKey'):
-        api_client.call_api.return_value = Token(token="session_token")
+        api_client.call_api.return_value = Token(token='session_token')
 
         obo_authenticator = OboAuthenticatorRsa(config, api_client)
         obo_session = obo_authenticator.authenticate_by_user_id(1234)
 
-        assert await obo_session.session_token == "session_token"
-
+        assert await obo_session.session_token == 'session_token'

--- a/tests/core/auth/obo_authenticator_test.py
+++ b/tests/core/auth/obo_authenticator_test.py
@@ -10,18 +10,18 @@ from symphony.bdk.gen.exceptions import ApiException
 from symphony.bdk.gen.login_model.token import Token
 
 
-@pytest.fixture(name='config')
+@pytest.fixture(name="config")
 def fixture_config():
     app_config = {
-        'appId': 'test_bot',
-        'privateKey': {
-            'path': 'path/to/private_key'
+        "appId": "test_bot",
+        "privateKey": {
+            "path": "path/to/private_key"
         }
     }
     return BdkAppConfig(app_config)
 
 
-@pytest.fixture(name='api_client')
+@pytest.fixture(name="api_client")
 def fixture_api_client():
     api_client = MagicMock(ApiClient)
     api_client.call_api = AsyncMock()
@@ -31,35 +31,35 @@ def fixture_api_client():
 
 @pytest.mark.asyncio
 async def test_obo_session_username(config, api_client):
-    with patch('symphony.bdk.core.auth.obo_authenticator.create_signed_jwt', return_value='privateKey'):
-        api_client.call_api.return_value = Token(token='session_token')
+    with patch("symphony.bdk.core.auth.obo_authenticator.create_signed_jwt", return_value="privateKey"):
+        api_client.call_api.return_value = Token(token="session_token")
 
         obo_authenticator = OboAuthenticatorRsa(config, api_client)
-        session_token = await obo_authenticator.retrieve_obo_session_token_by_username('username')
+        session_token = await obo_authenticator.retrieve_obo_session_token_by_username("username")
 
-        assert session_token == 'session_token'
+        assert session_token == "session_token"
 
 
 @pytest.mark.asyncio
 async def test_obo_session_user_id(config, api_client):
-    with patch('symphony.bdk.core.auth.obo_authenticator.create_signed_jwt', return_value='privateKey'):
-        api_client.call_api.return_value = Token(token='session_token')
+    with patch("symphony.bdk.core.auth.obo_authenticator.create_signed_jwt", return_value="privateKey"):
+        api_client.call_api.return_value = Token(token="session_token")
 
         obo_authenticator = OboAuthenticatorRsa(config, api_client)
         session_token = await obo_authenticator.retrieve_obo_session_token_by_user_id(1234)
 
-        assert session_token == 'session_token'
+        assert session_token == "session_token"
 
 
 @pytest.mark.asyncio
 async def test_api_exception(config, api_client):
-    with patch('symphony.bdk.core.auth.obo_authenticator.create_signed_jwt', return_value='privateKey'):
+    with patch("symphony.bdk.core.auth.obo_authenticator.create_signed_jwt", return_value="privateKey"):
         api_client.call_api.side_effect = ApiException()
 
         obo_authenticator = OboAuthenticatorRsa(config, api_client)
 
         with pytest.raises(AuthUnauthorizedError):
-            await obo_authenticator.retrieve_obo_session_token_by_username('username')
+            await obo_authenticator.retrieve_obo_session_token_by_username("username")
 
         with pytest.raises(AuthUnauthorizedError):
             await obo_authenticator.retrieve_obo_session_token_by_user_id(1234)
@@ -67,21 +67,21 @@ async def test_api_exception(config, api_client):
 
 @pytest.mark.asyncio
 async def test_authenticate_by_username(config, api_client):
-    with patch('symphony.bdk.core.auth.obo_authenticator.create_signed_jwt', return_value='privateKey'):
-        api_client.call_api.return_value = Token(token='session_token')
+    with patch("symphony.bdk.core.auth.obo_authenticator.create_signed_jwt", return_value="privateKey"):
+        api_client.call_api.return_value = Token(token="session_token")
 
         obo_authenticator = OboAuthenticatorRsa(config, api_client)
-        obo_session = obo_authenticator.authenticate_by_username('username')
+        obo_session = obo_authenticator.authenticate_by_username("username")
 
-        assert await obo_session.session_token == 'session_token'
+        assert await obo_session.session_token == "session_token"
 
 
 @pytest.mark.asyncio
 async def test_authenticate_by_user_id(config, api_client):
-    with patch('symphony.bdk.core.auth.obo_authenticator.create_signed_jwt', return_value='privateKey'):
-        api_client.call_api.return_value = Token(token='session_token')
+    with patch("symphony.bdk.core.auth.obo_authenticator.create_signed_jwt", return_value="privateKey"):
+        api_client.call_api.return_value = Token(token="session_token")
 
         obo_authenticator = OboAuthenticatorRsa(config, api_client)
         obo_session = obo_authenticator.authenticate_by_user_id(1234)
 
-        assert await obo_session.session_token == 'session_token'
+        assert await obo_session.session_token == "session_token"

--- a/tests/core/client/api_client_factory_test.py
+++ b/tests/core/client/api_client_factory_test.py
@@ -8,10 +8,10 @@ from symphony.bdk.core.config.model.bdk_config import BdkConfig
 from symphony.bdk.core.config.model.bdk_server_config import BdkProxyConfig
 from symphony.bdk.core.config.model.bdk_ssl_config import BdkSslConfig
 
-HOST = 'acme.symphony.com'
+HOST = "acme.symphony.com"
 
 
-@pytest.fixture(name='config')
+@pytest.fixture(name="config")
 def fixture_config():
     return BdkConfig(host=HOST)
 
@@ -20,41 +20,41 @@ def fixture_config():
 async def test_host_configured(config):
     client_factory = ApiClientFactory(config)
 
-    assert_host_configured_only(client_factory.get_pod_client(), '/pod')
-    assert_host_configured_only(client_factory.get_login_client(), '/login')
-    assert_host_configured_only(client_factory.get_agent_client(), '/agent')
-    assert_host_configured_only(client_factory.get_session_auth_client(), '/sessionauth')
-    assert_host_configured_only(client_factory.get_relay_client(), '/relay')
+    assert_host_configured_only(client_factory.get_pod_client(), "/pod")
+    assert_host_configured_only(client_factory.get_login_client(), "/login")
+    assert_host_configured_only(client_factory.get_agent_client(), "/agent")
+    assert_host_configured_only(client_factory.get_session_auth_client(), "/sessionauth")
+    assert_host_configured_only(client_factory.get_relay_client(), "/relay")
 
 
 @pytest.mark.asyncio
 async def test_proxy_configured(config):
-    proxy_host = 'proxy.com'
+    proxy_host = "proxy.com"
     proxy_port = 1234
     config.proxy = BdkProxyConfig(proxy_host, proxy_port)
     client_factory = ApiClientFactory(config)
 
-    assert_host_and_proxy_configured(client_factory.get_pod_client(), '/pod', proxy_host, proxy_port)
-    assert_host_and_proxy_configured(client_factory.get_login_client(), '/login', proxy_host, proxy_port)
-    assert_host_and_proxy_configured(client_factory.get_agent_client(), '/agent', proxy_host, proxy_port)
-    assert_host_and_proxy_configured(client_factory.get_session_auth_client(), '/sessionauth', proxy_host,
+    assert_host_and_proxy_configured(client_factory.get_pod_client(), "/pod", proxy_host, proxy_port)
+    assert_host_and_proxy_configured(client_factory.get_login_client(), "/login", proxy_host, proxy_port)
+    assert_host_and_proxy_configured(client_factory.get_agent_client(), "/agent", proxy_host, proxy_port)
+    assert_host_and_proxy_configured(client_factory.get_session_auth_client(), "/sessionauth", proxy_host,
                                      proxy_port)
-    assert_host_and_proxy_configured(client_factory.get_relay_client(), '/relay', proxy_host, proxy_port)
+    assert_host_and_proxy_configured(client_factory.get_relay_client(), "/relay", proxy_host, proxy_port)
 
 
 @pytest.mark.asyncio
 async def test_proxy_credentials_configured(config):
-    proxy_host = 'proxy.com'
+    proxy_host = "proxy.com"
     proxy_port = 1234
-    config.proxy = BdkProxyConfig(proxy_host, proxy_port, 'user', 'pass')
+    config.proxy = BdkProxyConfig(proxy_host, proxy_port, "user", "pass")
     client_factory = ApiClientFactory(config)
 
-    assert_host_and_proxy_credentials_configured(client_factory.get_pod_client(), '/pod', proxy_host, proxy_port)
-    assert_host_and_proxy_credentials_configured(client_factory.get_login_client(), '/login', proxy_host, proxy_port)
-    assert_host_and_proxy_credentials_configured(client_factory.get_agent_client(), '/agent', proxy_host, proxy_port)
-    assert_host_and_proxy_credentials_configured(client_factory.get_session_auth_client(), '/sessionauth', proxy_host,
+    assert_host_and_proxy_credentials_configured(client_factory.get_pod_client(), "/pod", proxy_host, proxy_port)
+    assert_host_and_proxy_credentials_configured(client_factory.get_login_client(), "/login", proxy_host, proxy_port)
+    assert_host_and_proxy_credentials_configured(client_factory.get_agent_client(), "/agent", proxy_host, proxy_port)
+    assert_host_and_proxy_credentials_configured(client_factory.get_session_auth_client(), "/sessionauth", proxy_host,
                                                  proxy_port)
-    assert_host_and_proxy_credentials_configured(client_factory.get_relay_client(), '/relay', proxy_host, proxy_port)
+    assert_host_and_proxy_credentials_configured(client_factory.get_relay_client(), "/relay", proxy_host, proxy_port)
 
 
 @pytest.mark.asyncio
@@ -201,9 +201,9 @@ def assert_default_headers(actual, expected):
 
 
 def test_trust_store_configured(config):
-    with patch('symphony.bdk.gen.rest.RESTClientObject'):
-        truststore_path = '/path/to/truststore.pem'
-        config.ssl = BdkSslConfig({'trustStore': {'path': truststore_path}})
+    with patch("symphony.bdk.gen.rest.RESTClientObject"):
+        truststore_path = "/path/to/truststore.pem"
+        config.ssl = BdkSslConfig({"trustStore": {"path": truststore_path}})
 
         client_factory = ApiClientFactory(config)
 

--- a/tests/core/client/api_client_factory_test.py
+++ b/tests/core/client/api_client_factory_test.py
@@ -7,11 +7,11 @@ from symphony.bdk.core.config.model.bdk_config import BdkConfig
 from symphony.bdk.core.config.model.bdk_server_config import BdkProxyConfig
 from symphony.bdk.core.config.model.bdk_ssl_config import BdkSslConfig
 
-HOST = "acme.symphony.com"
+HOST = 'acme.symphony.com'
 
 
-@pytest.fixture()
-def config():
+@pytest.fixture(name='config')
+def fixture_config():
     return BdkConfig(host=HOST)
 
 
@@ -19,52 +19,52 @@ def config():
 async def test_host_configured(config):
     client_factory = ApiClientFactory(config)
 
-    assert_host_configured_only(client_factory.get_pod_client().configuration, "/pod")
-    assert_host_configured_only(client_factory.get_login_client().configuration, "/login")
-    assert_host_configured_only(client_factory.get_agent_client().configuration, "/agent")
-    assert_host_configured_only(client_factory.get_session_auth_client().configuration, "/sessionauth")
-    assert_host_configured_only(client_factory.get_relay_client().configuration, "/relay")
+    assert_host_configured_only(client_factory.get_pod_client().configuration, '/pod')
+    assert_host_configured_only(client_factory.get_login_client().configuration, '/login')
+    assert_host_configured_only(client_factory.get_agent_client().configuration, '/agent')
+    assert_host_configured_only(client_factory.get_session_auth_client().configuration, '/sessionauth')
+    assert_host_configured_only(client_factory.get_relay_client().configuration, '/relay')
 
 
 @pytest.mark.asyncio
 async def test_proxy_configured(config):
-    proxy_host = "proxy.com"
+    proxy_host = 'proxy.com'
     proxy_port = 1234
     config.proxy = BdkProxyConfig(proxy_host, proxy_port)
     client_factory = ApiClientFactory(config)
 
-    assert_host_and_proxy_configured(client_factory.get_pod_client().configuration, "/pod", proxy_host, proxy_port)
-    assert_host_and_proxy_configured(client_factory.get_login_client().configuration, "/login", proxy_host, proxy_port)
-    assert_host_and_proxy_configured(client_factory.get_agent_client().configuration, "/agent", proxy_host, proxy_port)
-    assert_host_and_proxy_configured(client_factory.get_session_auth_client().configuration, "/sessionauth", proxy_host,
+    assert_host_and_proxy_configured(client_factory.get_pod_client().configuration, '/pod', proxy_host, proxy_port)
+    assert_host_and_proxy_configured(client_factory.get_login_client().configuration, '/login', proxy_host, proxy_port)
+    assert_host_and_proxy_configured(client_factory.get_agent_client().configuration, '/agent', proxy_host, proxy_port)
+    assert_host_and_proxy_configured(client_factory.get_session_auth_client().configuration, '/sessionauth', proxy_host,
                                      proxy_port)
-    assert_host_and_proxy_configured(client_factory.get_relay_client().configuration, "/relay", proxy_host, proxy_port)
+    assert_host_and_proxy_configured(client_factory.get_relay_client().configuration, '/relay', proxy_host, proxy_port)
 
 
 @pytest.mark.asyncio
 async def test_proxy_credentials_configured(config):
-    proxy_host = "proxy.com"
+    proxy_host = 'proxy.com'
     proxy_port = 1234
-    config.proxy = BdkProxyConfig(proxy_host, proxy_port, "user", "pass")
+    config.proxy = BdkProxyConfig(proxy_host, proxy_port, 'user', 'pass')
     client_factory = ApiClientFactory(config)
 
-    assert_host_and_proxy_credentials_configured(client_factory.get_pod_client().configuration, "/pod", proxy_host,
+    assert_host_and_proxy_credentials_configured(client_factory.get_pod_client().configuration, '/pod', proxy_host,
                                                  proxy_port)
-    assert_host_and_proxy_credentials_configured(client_factory.get_login_client().configuration, "/login", proxy_host,
+    assert_host_and_proxy_credentials_configured(client_factory.get_login_client().configuration, '/login', proxy_host,
                                                  proxy_port)
-    assert_host_and_proxy_credentials_configured(client_factory.get_agent_client().configuration, "/agent", proxy_host,
+    assert_host_and_proxy_credentials_configured(client_factory.get_agent_client().configuration, '/agent', proxy_host,
                                                  proxy_port)
-    assert_host_and_proxy_credentials_configured(client_factory.get_session_auth_client().configuration, "/sessionauth",
+    assert_host_and_proxy_credentials_configured(client_factory.get_session_auth_client().configuration, '/sessionauth',
                                                  proxy_host,
                                                  proxy_port)
-    assert_host_and_proxy_credentials_configured(client_factory.get_relay_client().configuration, "/relay", proxy_host,
+    assert_host_and_proxy_credentials_configured(client_factory.get_relay_client().configuration, '/relay', proxy_host,
                                                  proxy_port)
 
 
 def test_trust_store_configured(config):
-    with patch("symphony.bdk.gen.rest.RESTClientObject"):
-        truststore_path = "/path/to/truststore.pem"
-        config.ssl = BdkSslConfig({"trustStore": {"path": truststore_path}})
+    with patch('symphony.bdk.gen.rest.RESTClientObject'):
+        truststore_path = '/path/to/truststore.pem'
+        config.ssl = BdkSslConfig({'trustStore': {'path': truststore_path}})
 
         client_factory = ApiClientFactory(config)
 
@@ -72,18 +72,18 @@ def test_trust_store_configured(config):
 
 
 def assert_host_configured_only(configuration, url_suffix):
-    assert configuration.host == f"https://{HOST}:443{url_suffix}"
+    assert configuration.host == f'https://{HOST}:443{url_suffix}'
     assert configuration.proxy is None
     assert configuration.proxy_headers is None
 
 
 def assert_host_and_proxy_configured(configuration, url_suffix, proxy_host, proxy_port):
-    assert configuration.host == f"https://{HOST}:443{url_suffix}"
-    assert configuration.proxy == f"http://{proxy_host}:{proxy_port}"
+    assert configuration.host == f'https://{HOST}:443{url_suffix}'
+    assert configuration.proxy == f'http://{proxy_host}:{proxy_port}'
     assert configuration.proxy_headers is None
 
 
 def assert_host_and_proxy_credentials_configured(configuration, url_suffix, proxy_host, proxy_port):
-    assert configuration.host == f"https://{HOST}:443{url_suffix}"
-    assert configuration.proxy == f"http://{proxy_host}:{proxy_port}"
-    assert "proxy-authorization" in configuration.proxy_headers
+    assert configuration.host == f'https://{HOST}:443{url_suffix}'
+    assert configuration.proxy == f'http://{proxy_host}:{proxy_port}'
+    assert 'proxy-authorization' in configuration.proxy_headers

--- a/tests/core/client/api_client_factory_test.py
+++ b/tests/core/client/api_client_factory_test.py
@@ -20,11 +20,11 @@ def fixture_config():
 async def test_host_configured(config):
     client_factory = ApiClientFactory(config)
 
-    assert_host_configured_only(client_factory.get_pod_client().configuration, '/pod')
-    assert_host_configured_only(client_factory.get_login_client().configuration, '/login')
-    assert_host_configured_only(client_factory.get_agent_client().configuration, '/agent')
-    assert_host_configured_only(client_factory.get_session_auth_client().configuration, '/sessionauth')
-    assert_host_configured_only(client_factory.get_relay_client().configuration, '/relay')
+    assert_host_configured_only(client_factory.get_pod_client(), '/pod')
+    assert_host_configured_only(client_factory.get_login_client(), '/login')
+    assert_host_configured_only(client_factory.get_agent_client(), '/agent')
+    assert_host_configured_only(client_factory.get_session_auth_client(), '/sessionauth')
+    assert_host_configured_only(client_factory.get_relay_client(), '/relay')
 
 
 @pytest.mark.asyncio
@@ -124,7 +124,7 @@ async def test_user_agent_configured_at_km_level(config):
     assert_default_user_agent_configured(client_factory.get_login_client().user_agent)
     assert_default_user_agent_configured(client_factory.get_agent_client().user_agent)
     assert_default_user_agent_configured(client_factory.get_session_auth_client().user_agent)
-    client_factory.get_relay_client().user_agent == custom_user_agent
+    assert client_factory.get_relay_client().user_agent == custom_user_agent
 
 
 @pytest.mark.asyncio

--- a/tests/core/config/bdk_config_loader_test.py
+++ b/tests/core/config/bdk_config_loader_test.py
@@ -9,49 +9,49 @@ from symphony.bdk.core.config.loader import BdkConfigLoader
 from symphony.bdk.core.config.exception import BdkConfigError
 
 
-@pytest.fixture(name='simple_config_path', params=['config.json', 'config.yaml'])
+@pytest.fixture(name="simple_config_path", params=["config.json", "config.yaml"])
 def fixture_simple_config_path(request):
     return get_config_resource_filepath(request.param)
 
 
-@pytest.fixture(name='global_config_path', params=['config_global.json', 'config_global.yaml'])
+@pytest.fixture(name="global_config_path", params=["config_global.json", "config_global.yaml"])
 def fixture_global_config_path(request):
     return get_config_resource_filepath(request.param)
 
 
-@pytest.fixture(name='wrong_path', params=['/wrong_path/config.json', '/wrong_path/wrong_extension.something'])
+@pytest.fixture(name="wrong_path", params=["/wrong_path/config.json", "/wrong_path/wrong_extension.something"])
 def fixture_wrong_path(request):
     return request.param
 
 
 def test_load_from_file(simple_config_path):
     config = BdkConfigLoader.load_from_file(simple_config_path)
-    assert config.bot.username == 'youbot'
+    assert config.bot.username == "youbot"
 
 
 def test_load_from_content(simple_config_path):
     config_path = Path(simple_config_path)
     content = config_path.read_text()
     config = BdkConfigLoader.load_from_content(content)
-    assert config.bot.username == 'youbot'
+    assert config.bot.username == "youbot"
 
 
 def test_load_from_file_not_found(wrong_path):
-    fail_error_message = f'Config file has not been found at: {Path(wrong_path).absolute()}'
+    fail_error_message = f"Config file has not been found at: {Path(wrong_path).absolute()}"
     with pytest.raises(BdkConfigError, match=re.escape(fail_error_message)):
         BdkConfigLoader.load_from_file(wrong_path)
 
 
-@pytest.mark.skipif(os.environ.get('CI') == 'true',
-                    reason='GitHub actions does not allow to create file in the home directory')
+@pytest.mark.skipif(os.environ.get("CI") == "true",
+                    reason="GitHub actions does not allow to create file in the home directory")
 def test_load_from_symphony_directory(simple_config_path):
-    tmp_config_filename = str(uuid.uuid4()) + '-config.yaml'
-    tmp_config_path = Path.home() / '.symphony' / tmp_config_filename
+    tmp_config_filename = str(uuid.uuid4()) + "-config.yaml"
+    tmp_config_path = Path.home() / ".symphony" / tmp_config_filename
     tmp_config_path.touch(exist_ok=True)
     resource_config_content = Path(simple_config_path).read_text()
     tmp_config_path.write_text(resource_config_content)
     config = BdkConfigLoader.load_from_symphony_dir(tmp_config_filename)
-    assert config.bot.username == 'youbot'
+    assert config.bot.username == "youbot"
 
 
 def test_load_client_global_config(global_config_path):
@@ -94,12 +94,12 @@ def test_load_client_global_config(global_config_path):
 
 
 def test_load_proxy_defined_at_global_level():
-    config = BdkConfigLoader.load_from_file(get_config_resource_filepath('config_global_proxy.yaml'))
+    config = BdkConfigLoader.load_from_file(get_config_resource_filepath("config_global_proxy.yaml"))
 
-    assert config.proxy.host == 'proxy.symphony.com'
+    assert config.proxy.host == "proxy.symphony.com"
     assert config.proxy.port == 1234
-    assert config.proxy.username == 'proxyuser'
-    assert config.proxy.password == 'proxypass'
+    assert config.proxy.username == "proxyuser"
+    assert config.proxy.password == "proxypass"
 
     assert config.agent.proxy == config.proxy
     assert config.pod.proxy == config.proxy
@@ -108,32 +108,32 @@ def test_load_proxy_defined_at_global_level():
 
 
 def test_load_proxy_defined_at_global_and_child_level():
-    config = BdkConfigLoader.load_from_file(get_config_resource_filepath('config_proxy_global_child.yaml'))
+    config = BdkConfigLoader.load_from_file(get_config_resource_filepath("config_proxy_global_child.yaml"))
 
-    assert config.proxy.host == 'proxy.symphony.com'
+    assert config.proxy.host == "proxy.symphony.com"
     assert config.proxy.port == 1234
-    assert config.proxy.username == 'proxyuser'
-    assert config.proxy.password == 'proxypass'
+    assert config.proxy.username == "proxyuser"
+    assert config.proxy.password == "proxypass"
 
     assert config.pod.proxy == config.proxy
     assert config.key_manager.proxy == config.proxy
     assert config.session_auth.proxy == config.proxy
 
-    assert config.agent.proxy.host == 'agent-proxy.symphony.com'
+    assert config.agent.proxy.host == "agent-proxy.symphony.com"
     assert config.agent.proxy.port == 5678
     assert config.agent.proxy.username is None
     assert config.agent.proxy.password is None
 
 
 def test_load_proxy_defined_at_child_level_only():
-    config = BdkConfigLoader.load_from_file(get_config_resource_filepath('config_proxy_child_only.yaml'))
+    config = BdkConfigLoader.load_from_file(get_config_resource_filepath("config_proxy_child_only.yaml"))
 
     assert config.proxy is None
     assert config.pod.proxy is None
     assert config.key_manager.proxy is None
     assert config.session_auth.proxy is None
 
-    assert config.agent.proxy.host == 'agent-proxy.symphony.com'
+    assert config.agent.proxy.host == "agent-proxy.symphony.com"
     assert config.agent.proxy.port == 5678
     assert config.agent.proxy.username is None
     assert config.agent.proxy.password is None

--- a/tests/core/config/bdk_config_loader_test.py
+++ b/tests/core/config/bdk_config_loader_test.py
@@ -1,92 +1,91 @@
 import re
+import os
+import uuid
+import pytest
 
+from pathlib import Path
 from tests.utils.resource_utils import get_config_resource_filepath
 from symphony.bdk.core.config.loader import BdkConfigLoader
 from symphony.bdk.core.config.exception import BdkConfigError
 
-import os
-import pytest
-from pathlib import Path
-import uuid
 
-
-@pytest.fixture(params=["config.json", "config.yaml"])
-def simple_config_path(request):
+@pytest.fixture(name='simple_config_path', params=['config.json', 'config.yaml'])
+def fixture_simple_config_path(request):
     return get_config_resource_filepath(request.param)
 
 
-@pytest.fixture(params=["config_global.json", "config_global.yaml"])
-def global_config_path(request):
+@pytest.fixture(name='global_config_path', params=['config_global.json', 'config_global.yaml'])
+def fixture_global_config_path(request):
     return get_config_resource_filepath(request.param)
 
 
-@pytest.fixture(params=["/wrong_path/config.json", "/wrong_path/wrong_extension.something"])
-def wrong_path(request):
+@pytest.fixture(name='wrong_path', params=['/wrong_path/config.json', '/wrong_path/wrong_extension.something'])
+def fixture_wrong_path(request):
     return request.param
 
 
 def test_load_from_file(simple_config_path):
     config = BdkConfigLoader.load_from_file(simple_config_path)
-    assert config.bot.username == "youbot"
+    assert config.bot.username == 'youbot'
 
 
 def test_load_from_content(simple_config_path):
     config_path = Path(simple_config_path)
     content = config_path.read_text()
     config = BdkConfigLoader.load_from_content(content)
-    assert config.bot.username == "youbot"
+    assert config.bot.username == 'youbot'
 
 
 def test_load_from_file_not_found(wrong_path):
-    fail_error_message = f"Config file has not been found at: {Path(wrong_path).absolute()}"
+    fail_error_message = f'Config file has not been found at: {Path(wrong_path).absolute()}'
     with pytest.raises(BdkConfigError, match=re.escape(fail_error_message)):
         BdkConfigLoader.load_from_file(wrong_path)
 
 
-@pytest.mark.skipif(os.environ.get("CI") == "true",
-                    reason="GitHub actions does not allow to create file in the home directory")
+@pytest.mark.skipif(os.environ.get('CI') == 'true',
+                    reason='GitHub actions does not allow to create file in the home directory')
 def test_load_from_symphony_directory(simple_config_path):
-    tmp_config_filename = str(uuid.uuid4()) + "-config.yaml"
-    tmp_config_path = Path.home() / ".symphony" / tmp_config_filename
+    tmp_config_filename = str(uuid.uuid4()) + '-config.yaml'
+    tmp_config_path = Path.home() / '.symphony' / tmp_config_filename
     tmp_config_path.touch(exist_ok=True)
     resource_config_content = Path(simple_config_path).read_text()
     tmp_config_path.write_text(resource_config_content)
     config = BdkConfigLoader.load_from_symphony_dir(tmp_config_filename)
-    assert config.bot.username == "youbot"
+    assert config.bot.username == 'youbot'
 
 
 def test_load_client_global_config(global_config_path):
     config = BdkConfigLoader.load_from_file(global_config_path)
-    assert config.pod.scheme == "https"
-    assert config.pod.host == "diff-pod.symphony.com"
+    assert config.pod.scheme == 'https'
+    assert config.pod.host == 'diff-pod.symphony.com'
     assert config.pod.port == 8443
-    assert config.pod.context == "context"
+    assert config.pod.context == 'context'
 
-    assert config.scheme == "https"
+    assert config.scheme == 'https'
 
-    assert config.agent.scheme == "https"
-    assert config.agent.host == "devx1.symphony.com"
+    assert config.agent.scheme == 'https'
+    assert config.agent.host == 'devx1.symphony.com'
     assert config.agent.port == 443
-    assert config.agent.get_formatted_context() == "/context"
+    assert config.agent.get_formatted_context() == '/context'
 
-    assert config.key_manager.scheme == "https"
-    assert config.key_manager.host == "devx1.symphony.com"
+    assert config.key_manager.scheme == 'https'
+    assert config.key_manager.host == 'devx1.symphony.com'
     assert config.key_manager.port == 8443
-    assert config.key_manager.get_formatted_context() == "/diff-context"
+    assert config.key_manager.get_formatted_context() == '/diff-context'
 
-    assert config.session_auth.scheme == "http"
-    assert config.session_auth.host == "devx1.symphony.com"
+    assert config.session_auth.scheme == 'http'
+    assert config.session_auth.host == 'devx1.symphony.com'
     assert config.session_auth.port == 8443
-    assert config.session_auth.context == "context"
+    assert config.session_auth.context == 'context'
 
 
 def test_load_proxy_defined_at_global_level():
-    config = BdkConfigLoader.load_from_file(get_config_resource_filepath("config_global_proxy.yaml"))
+    config = BdkConfigLoader.load_from_file(get_config_resource_filepath('config_global_proxy.yaml'))
 
-    assert config.proxy.host == "proxy.symphony.com"
+    assert config.proxy.host == 'proxy.symphony.com'
     assert config.proxy.port == 1234
-    assert config.proxy.username == "proxyuser"
-    assert config.proxy.password == "proxypass"
+    assert config.proxy.username == 'proxyuser'
+    assert config.proxy.password == 'proxypass'
 
     assert config.agent.proxy == config.proxy
     assert config.pod.proxy == config.proxy
@@ -95,32 +94,32 @@ def test_load_proxy_defined_at_global_level():
 
 
 def test_load_proxy_defined_at_global_and_child_level():
-    config = BdkConfigLoader.load_from_file(get_config_resource_filepath("config_proxy_global_child.yaml"))
+    config = BdkConfigLoader.load_from_file(get_config_resource_filepath('config_proxy_global_child.yaml'))
 
-    assert config.proxy.host == "proxy.symphony.com"
+    assert config.proxy.host == 'proxy.symphony.com'
     assert config.proxy.port == 1234
-    assert config.proxy.username == "proxyuser"
-    assert config.proxy.password == "proxypass"
+    assert config.proxy.username == 'proxyuser'
+    assert config.proxy.password == 'proxypass'
 
     assert config.pod.proxy == config.proxy
     assert config.key_manager.proxy == config.proxy
     assert config.session_auth.proxy == config.proxy
 
-    assert config.agent.proxy.host == "agent-proxy.symphony.com"
+    assert config.agent.proxy.host == 'agent-proxy.symphony.com'
     assert config.agent.proxy.port == 5678
     assert config.agent.proxy.username is None
     assert config.agent.proxy.password is None
 
 
 def test_load_proxy_defined_at_child_level_only():
-    config = BdkConfigLoader.load_from_file(get_config_resource_filepath("config_proxy_child_only.yaml"))
+    config = BdkConfigLoader.load_from_file(get_config_resource_filepath('config_proxy_child_only.yaml'))
 
     assert config.proxy is None
     assert config.pod.proxy is None
     assert config.key_manager.proxy is None
     assert config.session_auth.proxy is None
 
-    assert config.agent.proxy.host == "agent-proxy.symphony.com"
+    assert config.agent.proxy.host == 'agent-proxy.symphony.com'
     assert config.agent.proxy.port == 5678
     assert config.agent.proxy.username is None
     assert config.agent.proxy.password is None

--- a/tests/core/config/bdk_config_parser_test.py
+++ b/tests/core/config/bdk_config_parser_test.py
@@ -6,27 +6,27 @@ from symphony.bdk.core.config.loader import BdkConfigParser
 from tests.utils.resource_utils import get_config_resource_filepath
 
 
-@pytest.fixture(name='invalid_config_path', params=['invalid_config.yaml'])
+@pytest.fixture(name="invalid_config_path", params=["invalid_config.yaml"])
 def fixture_invalid_config_path(request):
     return get_config_resource_filepath(request.param)
 
 
 def test_parse_config_json():
-    config_path = get_config_resource_filepath('config.json')
+    config_path = get_config_resource_filepath("config.json")
     with open(config_path) as json_file:
         config_data = BdkConfigParser.parse(json_file.read())
-    assert config_data['bot']['username'] == 'youbot'
+    assert config_data["bot"]["username"] == "youbot"
 
 
 def test_parse_config_yaml():
-    config_path = get_config_resource_filepath('config.yaml')
+    config_path = get_config_resource_filepath("config.yaml")
     with open(config_path) as yaml_file:
         config_data = BdkConfigParser.parse(yaml_file.read())
-    assert config_data['bot']['username'] == 'youbot'
+    assert config_data["bot"]["username"] == "youbot"
 
 
 def test_parse_config_wrong_format(invalid_config_path):
-    fail_error_message = 'Config file is neither in JSON nor in YAML format.'
+    fail_error_message = "Config file is neither in JSON nor in YAML format."
     with pytest.raises(BdkConfigError, match=fail_error_message):
         with open(invalid_config_path) as invalid_config_file:
             BdkConfigParser.parse(invalid_config_file.read())

--- a/tests/core/config/bdk_config_parser_test.py
+++ b/tests/core/config/bdk_config_parser_test.py
@@ -1,32 +1,32 @@
+import pytest
+
 from symphony.bdk.core.config.exception import BdkConfigError
 from symphony.bdk.core.config.loader import BdkConfigParser
 
 from tests.utils.resource_utils import get_config_resource_filepath
-import pytest
 
 
-@pytest.fixture(params=["invalid_config.yaml"])
-def invalid_config_path(request):
+@pytest.fixture(name='invalid_config_path', params=['invalid_config.yaml'])
+def fixture_invalid_config_path(request):
     return get_config_resource_filepath(request.param)
 
 
 def test_parse_config_json():
-    config_path = get_config_resource_filepath("config.json")
+    config_path = get_config_resource_filepath('config.json')
     with open(config_path) as json_file:
         config_data = BdkConfigParser.parse(json_file.read())
-    assert config_data["bot"]["username"] == "youbot"
+    assert config_data['bot']['username'] == 'youbot'
 
 
 def test_parse_config_yaml():
-    config_path = get_config_resource_filepath("config.yaml")
+    config_path = get_config_resource_filepath('config.yaml')
     with open(config_path) as yaml_file:
         config_data = BdkConfigParser.parse(yaml_file.read())
-    assert config_data["bot"]["username"] == "youbot"
+    assert config_data['bot']['username'] == 'youbot'
 
 
 def test_parse_config_wrong_format(invalid_config_path):
-    fail_error_message = "Config file is neither in JSON nor in YAML format."
+    fail_error_message = 'Config file is neither in JSON nor in YAML format.'
     with pytest.raises(BdkConfigError, match=fail_error_message):
         with open(invalid_config_path) as invalid_config_file:
             BdkConfigParser.parse(invalid_config_file.read())
-

--- a/tests/core/config/bdk_config_test.py
+++ b/tests/core/config/bdk_config_test.py
@@ -6,14 +6,14 @@ from tests.utils.resource_utils import get_config_resource_filepath
 from tests.utils.resource_utils import get_resource_filepath
 
 
-@pytest.fixture(params=['config.json', 'config.yaml'])
-def simple_config_path(request):
+@pytest.fixture(name="simple_config_path", params=["config.json", "config.yaml"])
+def fixture_simple_config_path(request):
     return get_config_resource_filepath(request.param)
 
 
 def test_update_private_key(simple_config_path):
     config = BdkConfigLoader.load_from_file(simple_config_path)
-    private_key = get_resource_filepath('key/private_key.pem', as_text=False).read_text()
+    private_key = get_resource_filepath("key/private_key.pem", as_text=False).read_text()
     config.bot.private_key.content = private_key
     assert config.bot.private_key._content == private_key
     assert config.bot.private_key._path is None
@@ -21,7 +21,7 @@ def test_update_private_key(simple_config_path):
 
 def test_update_certificate(simple_config_path):
     config = BdkConfigLoader.load_from_file(simple_config_path)
-    certificate = get_resource_filepath('cert/certificate.cert', as_text=False).read_text()
+    certificate = get_resource_filepath("cert/certificate.cert", as_text=False).read_text()
     config.bot.certificate.content = certificate
     assert config.bot.certificate._content == certificate
     assert config.bot.certificate._path is None

--- a/tests/core/config/bdk_config_test.py
+++ b/tests/core/config/bdk_config_test.py
@@ -1,11 +1,12 @@
+import pytest
+
 from symphony.bdk.core.config.loader import BdkConfigLoader
 
 from tests.utils.resource_utils import get_config_resource_filepath
 from tests.utils.resource_utils import get_resource_filepath
-import pytest
 
 
-@pytest.fixture(params=["config.json", "config.yaml"])
+@pytest.fixture(params=['config.json', 'config.yaml'])
 def simple_config_path(request):
     return get_config_resource_filepath(request.param)
 
@@ -24,4 +25,3 @@ def test_update_certificate(simple_config_path):
     config.bot.certificate.content = certificate
     assert config.bot.certificate._content == certificate
     assert config.bot.certificate._path is None
-

--- a/tests/core/config/models/bdk_client_config_test.py
+++ b/tests/core/config/models/bdk_client_config_test.py
@@ -1,11 +1,12 @@
-from symphony.bdk.core.config.model.bdk_server_config import BdkServerConfig
-from symphony.bdk.core.config.model.bdk_client_config import BdkClientConfig
 import pytest
 
+from symphony.bdk.core.config.model.bdk_server_config import BdkServerConfig
+from symphony.bdk.core.config.model.bdk_client_config import BdkClientConfig
 
-@pytest.fixture(scope="module")
-def parent_config():
-    parent_config_dict = {"scheme": "parent_scheme", "host": "parent_host", "port": 0000, "context": "parent_context"}
+
+@pytest.fixture(name='parent_config', scope='module')
+def fixture_parent_config():
+    parent_config_dict = {'scheme': 'parent_scheme', 'host': 'parent_host', 'port': 0000, 'context': 'parent_context'}
     return BdkServerConfig(**parent_config_dict)
 
 
@@ -14,33 +15,33 @@ def test_empty_client(parent_config):
     empty_config_dict = {}
     client_config = BdkClientConfig(parent_config, empty_config_dict)
 
-    assert client_config.scheme == "parent_scheme"
-    assert client_config.host == "parent_host"
+    assert client_config.scheme == 'parent_scheme'
+    assert client_config.host == 'parent_host'
     assert client_config.port == 0000
-    assert client_config.context == "parent_context"
+    assert client_config.context == 'parent_context'
 
 
 def test_full_client(parent_config):
     """Should get the client_config attributes from the client config when defined"""
-    client_config_dict = {"scheme": "client_scheme", "host": "client_host", "port": 1111, "context": "client_context"}
+    client_config_dict = {'scheme': 'client_scheme', 'host': 'client_host', 'port': 1111, 'context': 'client_context'}
     client_config = BdkClientConfig(parent_config, client_config_dict)
 
-    assert client_config.scheme == "client_scheme"
-    assert client_config.host == "client_host"
+    assert client_config.scheme == 'client_scheme'
+    assert client_config.host == 'client_host'
     assert client_config.port == 1111
-    assert client_config.context == "client_context"
+    assert client_config.context == 'client_context'
 
 
 def test_get_base_path_from_client(parent_config):
-    client_config_dict = {"host": "dev.symphony.com", "port": 1234}
+    client_config_dict = {'host': 'dev.symphony.com', 'port': 1234}
     client_config = BdkClientConfig(parent_config, client_config_dict)
 
-    assert client_config.get_base_path() == "parent_scheme://dev.symphony.com:1234/parent_context"
+    assert client_config.get_base_path() == 'parent_scheme://dev.symphony.com:1234/parent_context'
 
 
 def test_get_base_path_from_client_no_root():
     parent_config = BdkServerConfig()
-    client_config_dict = {"host": "dev.symphony.com", "port": 1234}
+    client_config_dict = {'host': 'dev.symphony.com', 'port': 1234}
     client_config = BdkClientConfig(parent_config, client_config_dict)
 
-    assert client_config.get_base_path() == "https://dev.symphony.com:1234"
+    assert client_config.get_base_path() == 'https://dev.symphony.com:1234'

--- a/tests/core/config/models/bdk_client_config_test.py
+++ b/tests/core/config/models/bdk_client_config_test.py
@@ -4,9 +4,9 @@ from symphony.bdk.core.config.model.bdk_server_config import BdkServerConfig
 from symphony.bdk.core.config.model.bdk_client_config import BdkClientConfig
 
 
-@pytest.fixture(name='parent_config', scope='module')
+@pytest.fixture(name="parent_config", scope="module")
 def fixture_parent_config():
-    parent_config_dict = {'scheme': 'parent_scheme', 'host': 'parent_host', 'port': 0000, 'context': 'parent_context'}
+    parent_config_dict = {"scheme": "parent_scheme", "host": "parent_host", "port": 0000, "context": "parent_context"}
     return BdkServerConfig(**parent_config_dict)
 
 
@@ -15,33 +15,33 @@ def test_empty_client(parent_config):
     empty_config_dict = {}
     client_config = BdkClientConfig(parent_config, empty_config_dict)
 
-    assert client_config.scheme == 'parent_scheme'
-    assert client_config.host == 'parent_host'
+    assert client_config.scheme == "parent_scheme"
+    assert client_config.host == "parent_host"
     assert client_config.port == 0000
-    assert client_config.context == 'parent_context'
+    assert client_config.context == "parent_context"
 
 
 def test_full_client(parent_config):
     """Should get the client_config attributes from the client config when defined"""
-    client_config_dict = {'scheme': 'client_scheme', 'host': 'client_host', 'port': 1111, 'context': 'client_context'}
+    client_config_dict = {"scheme": "client_scheme", "host": "client_host", "port": 1111, "context": "client_context"}
     client_config = BdkClientConfig(parent_config, client_config_dict)
 
-    assert client_config.scheme == 'client_scheme'
-    assert client_config.host == 'client_host'
+    assert client_config.scheme == "client_scheme"
+    assert client_config.host == "client_host"
     assert client_config.port == 1111
-    assert client_config.context == 'client_context'
+    assert client_config.context == "client_context"
 
 
 def test_get_base_path_from_client(parent_config):
-    client_config_dict = {'host': 'dev.symphony.com', 'port': 1234}
+    client_config_dict = {"host": "dev.symphony.com", "port": 1234}
     client_config = BdkClientConfig(parent_config, client_config_dict)
 
-    assert client_config.get_base_path() == 'parent_scheme://dev.symphony.com:1234/parent_context'
+    assert client_config.get_base_path() == "parent_scheme://dev.symphony.com:1234/parent_context"
 
 
 def test_get_base_path_from_client_no_root():
     parent_config = BdkServerConfig()
-    client_config_dict = {'host': 'dev.symphony.com', 'port': 1234}
+    client_config_dict = {"host": "dev.symphony.com", "port": 1234}
     client_config = BdkClientConfig(parent_config, client_config_dict)
 
-    assert client_config.get_base_path() == 'https://dev.symphony.com:1234'
+    assert client_config.get_base_path() == "https://dev.symphony.com:1234"

--- a/tests/core/service/application/application_service_test.py
+++ b/tests/core/service/application/application_service_test.py
@@ -14,26 +14,26 @@ from symphony.bdk.gen.pod_model.user_app_entitlement_list import UserAppEntitlem
 from tests.utils.resource_utils import object_from_json_relative_path, object_from_json
 
 
-@pytest.fixture()
-def auth_session():
+@pytest.fixture(name='auth_session')
+def fixture_auth_session():
     bot_session = AuthSession(None)
     bot_session.session_token = 'session_token'
     bot_session.key_manager_token = 'km_token'
     return bot_session
 
 
-@pytest.fixture()
-def application_api():
+@pytest.fixture(name='application_api')
+def fixture_application_api():
     return MagicMock(ApplicationApi)
 
 
-@pytest.fixture()
-def app_entitlement_api():
+@pytest.fixture(name='app_entitlement_api')
+def fixture_app_entitlement_api():
     return MagicMock(AppEntitlementApi)
 
 
-@pytest.fixture()
-def application_service(application_api, app_entitlement_api, auth_session):
+@pytest.fixture(name='application_service')
+def fixture_application_service(application_api, app_entitlement_api, auth_session):
     service = ApplicationService(application_api, app_entitlement_api, auth_session)
     return service
 
@@ -152,7 +152,7 @@ async def test_update_application_entitlements(app_entitlement_api, application_
 async def test_list_user_applications(app_entitlement_api, application_service):
     app_entitlement_api.v1_admin_user_uid_app_entitlement_list_get = AsyncMock()
     app_entitlement_api.v1_admin_user_uid_app_entitlement_list_get.return_value =\
-        object_from_json_relative_path("application/list_user_apps.json")
+        object_from_json_relative_path('application/list_user_apps.json')
 
     user_app_entitlements = await application_service.list_user_applications(1234)
 
@@ -169,7 +169,7 @@ async def test_list_user_applications(app_entitlement_api, application_service):
 async def test_update_user_applications(app_entitlement_api, application_service):
     app_entitlement_api.v1_admin_user_uid_app_entitlement_list_post = AsyncMock()
     app_entitlement_api.v1_admin_user_uid_app_entitlement_list_post.return_value = \
-        object_from_json_relative_path("application/list_user_apps.json")
+        object_from_json_relative_path('application/list_user_apps.json')
 
     user_app_entitlement = UserAppEntitlement(
         app_id='djApp',

--- a/tests/core/service/application/application_service_test.py
+++ b/tests/core/service/application/application_service_test.py
@@ -14,25 +14,25 @@ from symphony.bdk.gen.pod_model.user_app_entitlement_list import UserAppEntitlem
 from tests.utils.resource_utils import object_from_json_relative_path, object_from_json
 
 
-@pytest.fixture(name='auth_session')
+@pytest.fixture(name="auth_session")
 def fixture_auth_session():
     bot_session = AuthSession(None)
-    bot_session.session_token = 'session_token'
-    bot_session.key_manager_token = 'km_token'
+    bot_session.session_token = "session_token"
+    bot_session.key_manager_token = "km_token"
     return bot_session
 
 
-@pytest.fixture(name='application_api')
+@pytest.fixture(name="application_api")
 def fixture_application_api():
     return MagicMock(ApplicationApi)
 
 
-@pytest.fixture(name='app_entitlement_api')
+@pytest.fixture(name="app_entitlement_api")
 def fixture_app_entitlement_api():
     return MagicMock(AppEntitlementApi)
 
 
-@pytest.fixture(name='application_service')
+@pytest.fixture(name="application_service")
 def fixture_application_service(application_api, app_entitlement_api, auth_session):
     service = ApplicationService(application_api, app_entitlement_api, auth_session)
     return service
@@ -42,35 +42,35 @@ def fixture_application_service(application_api, app_entitlement_api, auth_sessi
 async def test_create_application(application_api, application_service):
     application_api.v1_admin_app_create_post = AsyncMock()
     application_api.v1_admin_app_create_post.return_value = \
-        object_from_json_relative_path('application/create_application.json')
+        object_from_json_relative_path("application/create_application.json")
 
     application_detail = await application_service.create_application(ApplicationDetail())
 
     application_api.v1_admin_app_create_post.assert_called_with(
-        session_token='session_token',
+        session_token="session_token",
         application_detail=ApplicationDetail()
     )
 
-    assert application_detail.applicationInfo.appId == 'my-test-app'
-    assert application_detail.description == 'a test app'
+    assert application_detail.applicationInfo.appId == "my-test-app"
+    assert application_detail.description == "a test app"
 
 
 @pytest.mark.asyncio
 async def test_update_application(application_api, application_service):
     application_api.v1_admin_app_id_update_post = AsyncMock()
     application_api.v1_admin_app_id_update_post.return_value = \
-        object_from_json_relative_path('application/update_application.json')
+        object_from_json_relative_path("application/update_application.json")
 
-    application_detail = await application_service.update_application('my-test-app', ApplicationDetail())
+    application_detail = await application_service.update_application("my-test-app", ApplicationDetail())
 
     application_api.v1_admin_app_id_update_post.assert_called_with(
-        session_token='session_token',
-        id='my-test-app',
+        session_token="session_token",
+        id="my-test-app",
         application_detail=ApplicationDetail()
     )
 
-    assert application_detail.applicationInfo.appId == 'my-test-app'
-    assert application_detail.description == 'updating an app'
+    assert application_detail.applicationInfo.appId == "my-test-app"
+    assert application_detail.description == "updating an app"
 
 
 @pytest.mark.asyncio
@@ -83,11 +83,11 @@ async def test_delete_application(application_api, application_service):
         '}'
     )
 
-    await application_service.delete_application('my-test-app')
+    await application_service.delete_application("my-test-app")
 
     application_api.v1_admin_app_id_delete_post.assert_called_with(
-        session_token='session_token',
-        id='my-test-app'
+        session_token="session_token",
+        id="my-test-app"
     )
 
 
@@ -95,44 +95,44 @@ async def test_delete_application(application_api, application_service):
 async def test_get_application(application_api, application_service):
     application_api.v1_admin_app_id_get_get = AsyncMock()
     application_api.v1_admin_app_id_get_get.return_value =\
-        object_from_json_relative_path('application/get_application.json')
+        object_from_json_relative_path("application/get_application.json")
 
-    application_detail = await application_service.get_application('my-test-app')
+    application_detail = await application_service.get_application("my-test-app")
 
     application_api.v1_admin_app_id_get_get.assert_called_with(
-        session_token='session_token',
-        id='my-test-app'
+        session_token="session_token",
+        id="my-test-app"
     )
 
-    assert application_detail.applicationInfo.appId == 'my-test-app'
-    assert application_detail.description == 'get an app'
+    assert application_detail.applicationInfo.appId == "my-test-app"
+    assert application_detail.description == "get an app"
 
 
 @pytest.mark.asyncio
 async def test_list_application_entitlements(app_entitlement_api, application_service):
     app_entitlement_api.v1_admin_app_entitlement_list_get = AsyncMock()
     app_entitlement_api.v1_admin_app_entitlement_list_get.return_value = \
-        object_from_json_relative_path('application/list_app_entitlements.json')
+        object_from_json_relative_path("application/list_app_entitlements.json")
 
     pod_app_entitlements = await application_service.list_application_entitlements()
 
     app_entitlement_api.v1_admin_app_entitlement_list_get.assert_called_with(
-        session_token='session_token'
+        session_token="session_token"
     )
 
     assert len(pod_app_entitlements) == 3
-    assert pod_app_entitlements[0].appId == 'djApp'
+    assert pod_app_entitlements[0].appId == "djApp"
 
 
 @pytest.mark.asyncio
 async def test_update_application_entitlements(app_entitlement_api, application_service):
     app_entitlement_api.v1_admin_app_entitlement_list_post = AsyncMock()
     app_entitlement_api.v1_admin_app_entitlement_list_post.return_value = \
-        object_from_json_relative_path('application/update_app_entitlements.json')
+        object_from_json_relative_path("application/update_app_entitlements.json")
 
     pod_app_entitlement = PodAppEntitlement(
-        app_id='rsa-app-auth-example',
-        app_name='App Auth RSA Example',
+        app_id="rsa-app-auth-example",
+        app_name="App Auth RSA Example",
         enable=True,
         listed=True,
         install=False
@@ -140,39 +140,39 @@ async def test_update_application_entitlements(app_entitlement_api, application_
     pod_app_entitlements = await application_service.update_application_entitlements([pod_app_entitlement])
 
     app_entitlement_api.v1_admin_app_entitlement_list_post.assert_called_with(
-        session_token='session_token',
+        session_token="session_token",
         payload=PodAppEntitlementList(value=[pod_app_entitlement])
     )
 
     assert len(pod_app_entitlements) == 1
-    assert pod_app_entitlements[0].appId == 'rsa-app-auth-example'
+    assert pod_app_entitlements[0].appId == "rsa-app-auth-example"
 
 
 @pytest.mark.asyncio
 async def test_list_user_applications(app_entitlement_api, application_service):
     app_entitlement_api.v1_admin_user_uid_app_entitlement_list_get = AsyncMock()
     app_entitlement_api.v1_admin_user_uid_app_entitlement_list_get.return_value =\
-        object_from_json_relative_path('application/list_user_apps.json')
+        object_from_json_relative_path("application/list_user_apps.json")
 
     user_app_entitlements = await application_service.list_user_applications(1234)
 
     app_entitlement_api.v1_admin_user_uid_app_entitlement_list_get.assert_called_with(
-        session_token='session_token',
+        session_token="session_token",
         uid=1234
     )
 
     assert len(user_app_entitlements) == 3
-    assert user_app_entitlements[0].appId == 'djApp'
+    assert user_app_entitlements[0].appId == "djApp"
 
 
 @pytest.mark.asyncio
 async def test_update_user_applications(app_entitlement_api, application_service):
     app_entitlement_api.v1_admin_user_uid_app_entitlement_list_post = AsyncMock()
     app_entitlement_api.v1_admin_user_uid_app_entitlement_list_post.return_value = \
-        object_from_json_relative_path('application/list_user_apps.json')
+        object_from_json_relative_path("application/list_user_apps.json")
 
     user_app_entitlement = UserAppEntitlement(
-        app_id='djApp',
+        app_id="djApp",
         listed=True,
         install=False
     )
@@ -180,10 +180,10 @@ async def test_update_user_applications(app_entitlement_api, application_service
     user_app_entitlements = await application_service.update_user_applications(1234, [user_app_entitlement])
 
     app_entitlement_api.v1_admin_user_uid_app_entitlement_list_post.assert_called_with(
-        session_token='session_token',
+        session_token="session_token",
         uid=1234,
         payload=UserAppEntitlementList(value=[user_app_entitlement])
     )
 
     assert len(user_app_entitlements) == 3
-    assert user_app_entitlements[0].appId == 'djApp'
+    assert user_app_entitlements[0].appId == "djApp"

--- a/tests/core/service/connection/connection_service_test.py
+++ b/tests/core/service/connection/connection_service_test.py
@@ -10,20 +10,20 @@ from symphony.bdk.gen.pod_model.user_connection_request import UserConnectionReq
 from tests.utils.resource_utils import object_from_json
 
 
-@pytest.fixture(name='auth_session')
+@pytest.fixture(name="auth_session")
 def fixture_auth_session():
     bot_session = AuthSession(None)
-    bot_session.session_token = 'session_token'
-    bot_session.key_manager_token = 'km_token'
+    bot_session.session_token = "session_token"
+    bot_session.key_manager_token = "km_token"
     return bot_session
 
 
-@pytest.fixture(name='connection_api')
+@pytest.fixture(name="connection_api")
 def fixture_connection_api():
     return MagicMock(ConnectionApi)
 
 
-@pytest.fixture(name='connection_service')
+@pytest.fixture(name="connection_service")
 def fixture_connection_service(connection_api, auth_session):
     service = ConnectionService(
         connection_api,
@@ -45,8 +45,8 @@ async def test_get_connection(connection_api, connection_service):
     user_connection = await connection_service.get_connection(769658112378)
 
     connection_api.v1_connection_user_user_id_info_get.assert_called_with(
-        user_id='769658112378',
-        session_token='session_token'
+        user_id="769658112378",
+        session_token="session_token"
     )
     assert user_connection.userId == 769658112378
     assert user_connection.status == ConnectionStatus.ACCEPTED.value
@@ -75,9 +75,9 @@ async def test_list_connections(connection_api, connection_service):
     user_connections = await connection_service.list_connections(ConnectionStatus.ALL, [7078106126503, 7078106103809])
 
     connection_api.v1_connection_list_get.assert_called_with(
-        user_ids='7078106126503,7078106103809',
+        user_ids="7078106126503,7078106103809",
         status=ConnectionStatus.ALL.value,
-        session_token='session_token'
+        session_token="session_token"
     )
 
     assert len(user_connections) == 2
@@ -102,7 +102,7 @@ async def test_create_connection(connection_api, connection_service):
 
     connection_api.v1_connection_create_post.assert_called_with(
         connection_request=UserConnectionRequest(user_id=7078106126503),
-        session_token='session_token'
+        session_token="session_token"
     )
 
     assert user_connection.userId == 7078106126503
@@ -127,7 +127,7 @@ async def test_accept_connection(connection_api, connection_service):
 
     connection_api.v1_connection_accept_post.assert_called_with(
         connection_request=UserConnectionRequest(user_id=7078106169577),
-        session_token='session_token'
+        session_token="session_token"
     )
 
     assert user_connection.userId == 7078106169577
@@ -152,7 +152,7 @@ async def test_reject_connection(connection_api, connection_service):
 
     connection_api.v1_connection_reject_post.assert_called_with(
         connection_request=UserConnectionRequest(user_id=7215545059385),
-        session_token='session_token'
+        session_token="session_token"
     )
 
     assert user_connection.userId == 7215545059385
@@ -173,5 +173,5 @@ async def test_remove_connection(connection_api, connection_service):
 
     connection_api.v1_connection_user_uid_remove_post.assert_called_with(
         uid=1234,
-        session_token='session_token'
+        session_token="session_token"
     )

--- a/tests/core/service/connection/connection_service_test.py
+++ b/tests/core/service/connection/connection_service_test.py
@@ -10,21 +10,21 @@ from symphony.bdk.gen.pod_model.user_connection_request import UserConnectionReq
 from tests.utils.resource_utils import object_from_json
 
 
-@pytest.fixture()
-def auth_session():
+@pytest.fixture(name='auth_session')
+def fixture_auth_session():
     bot_session = AuthSession(None)
     bot_session.session_token = 'session_token'
     bot_session.key_manager_token = 'km_token'
     return bot_session
 
 
-@pytest.fixture()
-def connection_api():
+@pytest.fixture(name='connection_api')
+def fixture_connection_api():
     return MagicMock(ConnectionApi)
 
 
-@pytest.fixture()
-def connection_service(connection_api, auth_session):
+@pytest.fixture(name='connection_service')
+def fixture_connection_service(connection_api, auth_session):
     service = ConnectionService(
         connection_api,
         auth_session

--- a/tests/core/service/datafeed/datafeed_loop_v1_test.py
+++ b/tests/core/service/datafeed/datafeed_loop_v1_test.py
@@ -39,28 +39,28 @@ from tests.utils.resource_utils import get_resource_content
 from tests.core.test.in_memory_datafeed_id_repository import InMemoryDatafeedIdRepository
 from tests.utils.resource_utils import get_config_resource_filepath
 
-DEFAULT_AGENT_BASE_PATH: str = 'https://agent:8443/context'
+DEFAULT_AGENT_BASE_PATH: str = "https://agent:8443/context"
 
 
-@pytest.fixture(name='auth_session')
+@pytest.fixture(name="auth_session")
 def fixture_auth_session():
     auth_session = AuthSession(None)
-    auth_session.session_token = 'session_token'
-    auth_session.key_manager_token = 'km_token'
+    auth_session.session_token = "session_token"
+    auth_session.key_manager_token = "km_token"
     return auth_session
 
 
-@pytest.fixture(name='config')
+@pytest.fixture(name="config")
 def fixture_config():
-    return BdkConfigLoader.load_from_file(get_config_resource_filepath('config.yaml'))
+    return BdkConfigLoader.load_from_file(get_config_resource_filepath("config.yaml"))
 
 
-@pytest.fixture(name='datafeed_repository')
+@pytest.fixture(name="datafeed_repository")
 def fixture_datafeed_repository():
     return InMemoryDatafeedIdRepository(DEFAULT_AGENT_BASE_PATH)
 
 
-@pytest.fixture(name='datafeed_api')
+@pytest.fixture(name="datafeed_api")
 def fixture_datafeed_api():
     datafeed_api = MagicMock(DatafeedApi)
     datafeed_api.api_client = MagicMock(ApiClient)
@@ -69,17 +69,17 @@ def fixture_datafeed_api():
     return datafeed_api
 
 
-@pytest.fixture(name='mock_listener')
+@pytest.fixture(name="mock_listener")
 def fixture_mock_listener():
     return AsyncMock(wraps=RealTimeEventListener())
 
 
-@pytest.fixture(name='initiator')
+@pytest.fixture(name="initiator")
 def fixture_initiator():
-    return V4Initiator(user=V4User(username='username'))
+    return V4Initiator(user=V4User(username="username"))
 
 
-@pytest.fixture(name='message_sent_event')
+@pytest.fixture(name="message_sent_event")
 def fixture_message_sent_event(initiator):
     class EventsMock:
         def __init__(self, individual_event):
@@ -92,7 +92,7 @@ def fixture_message_sent_event(initiator):
     return event
 
 
-@pytest.fixture(name='datafeed_loop_v1')
+@pytest.fixture(name="datafeed_loop_v1")
 def fixture_datafeed_loop_v1(datafeed_api, auth_session, config, datafeed_repository):
     return auto_stopping_datafeed_loop_v1(datafeed_api, auth_session, config, datafeed_repository)
 
@@ -109,7 +109,7 @@ def auto_stopping_datafeed_loop_v1(datafeed_api, auth_session, config, repositor
     return datafeed_loop
 
 
-@pytest.fixture(name='datafeed_loop_with_listener')
+@pytest.fixture(name="datafeed_loop_with_listener")
 def fixture_datafeed_loop_with_listener(datafeed_api, auth_session, config, mock_listener):
     datafeed_loop = DatafeedLoopV1(datafeed_api, auth_session, config)
     datafeed_loop.subscribe(mock_listener)
@@ -118,7 +118,7 @@ def fixture_datafeed_loop_with_listener(datafeed_api, auth_session, config, mock
 
 @pytest.mark.asyncio
 async def test_start(datafeed_loop_v1, datafeed_api, message_sent_event):
-    datafeed_api.v4_datafeed_create_post.return_value = Datafeed(id='test_id')
+    datafeed_api.v4_datafeed_create_post.return_value = Datafeed(id="test_id")
     datafeed_api.v4_datafeed_id_read_get.return_value = message_sent_event
 
     await datafeed_loop_v1.start()
@@ -126,13 +126,13 @@ async def test_start(datafeed_loop_v1, datafeed_api, message_sent_event):
     datafeed_api.v4_datafeed_create_post.assert_called_once()
     datafeed_api.v4_datafeed_id_read_get.assert_called_once()
 
-    assert datafeed_loop_v1.datafeed_id == 'test_id'
+    assert datafeed_loop_v1.datafeed_id == "test_id"
     assert datafeed_loop_v1.datafeed_repository.read()
 
 
 @pytest.mark.asyncio
 async def test_datafeed_is_reused(datafeed_repository, datafeed_api, auth_session, config, message_sent_event):
-    datafeed_repository.write('persisted_id')
+    datafeed_repository.write("persisted_id")
     datafeed_loop = auto_stopping_datafeed_loop_v1(datafeed_api, auth_session, config, datafeed_repository)
 
     datafeed_api.v4_datafeed_id_read_get.return_value = message_sent_event
@@ -140,66 +140,66 @@ async def test_datafeed_is_reused(datafeed_repository, datafeed_api, auth_sessio
     await datafeed_loop.start()
 
     datafeed_api.v4_datafeed_create_post.assert_not_called()
-    datafeed_api.v4_datafeed_id_read_get.assert_called_once_with(id='persisted_id',
-                                                                 session_token='session_token',
-                                                                 key_manager_token='km_token')
+    datafeed_api.v4_datafeed_id_read_get.assert_called_once_with(id="persisted_id",
+                                                                 session_token="session_token",
+                                                                 key_manager_token="km_token")
 
 
 @pytest.mark.asyncio
 async def test_start_recreate_datafeed_error(datafeed_repository, datafeed_api, auth_session, config):
-    datafeed_repository.write('persisted_id')
+    datafeed_repository.write("persisted_id")
     datafeed_loop = auto_stopping_datafeed_loop_v1(datafeed_api, auth_session, config, datafeed_repository)
 
-    datafeed_api.v4_datafeed_id_read_get.side_effect = ApiException(400, 'Expired Datafeed id')
-    datafeed_api.v4_datafeed_create_post.side_effect = ApiException(500, 'Unhandled exception')
+    datafeed_api.v4_datafeed_id_read_get.side_effect = ApiException(400, "Expired Datafeed id")
+    datafeed_api.v4_datafeed_create_post.side_effect = ApiException(500, "Unhandled exception")
 
     with pytest.raises(ApiException):
         await datafeed_loop.start()
 
-    datafeed_api.v4_datafeed_id_read_get.assert_called_once_with(id='persisted_id',
-                                                                 session_token='session_token',
-                                                                 key_manager_token='km_token')
+    datafeed_api.v4_datafeed_id_read_get.assert_called_once_with(id="persisted_id",
+                                                                 session_token="session_token",
+                                                                 key_manager_token="km_token")
 
-    datafeed_api.v4_datafeed_create_post.assert_called_once_with(session_token='session_token',
-                                                                 key_manager_token='km_token')
+    datafeed_api.v4_datafeed_create_post.assert_called_once_with(session_token="session_token",
+                                                                 key_manager_token="km_token")
 
 
 @pytest.mark.asyncio
 async def test_retrieve_datafeed_from_datafeed_file(tmpdir, datafeed_api, auth_session, config, message_sent_event):
-    datafeed_file_content = get_resource_content('datafeed/datafeedId')
-    datafeed_file_path = tmpdir.join('datafeed.id')
+    datafeed_file_content = get_resource_content("datafeed/datafeedId")
+    datafeed_file_path = tmpdir.join("datafeed.id")
     datafeed_file_path.write(datafeed_file_content)
 
-    datafeed_config = BdkDatafeedConfig({'idFilePath': str(datafeed_file_path)})
+    datafeed_config = BdkDatafeedConfig({"idFilePath": str(datafeed_file_path)})
     config.datafeed = datafeed_config
 
     datafeed_loop = auto_stopping_datafeed_loop_v1(datafeed_api, auth_session, config)
     datafeed_api.v4_datafeed_id_read_get.return_value = message_sent_event
     await datafeed_loop.start()
 
-    assert datafeed_loop.datafeed_id == '8e7c8672-220'
+    assert datafeed_loop.datafeed_id == "8e7c8672-220"
 
 
 @pytest.mark.asyncio
 async def test_retrieve_datafeed_from_invalid_datafeed_dir(tmpdir, datafeed_api, auth_session, config,
                                                            message_sent_event):
-    datafeed_id_file_content = get_resource_content('datafeed/datafeedId')
-    datafeed_id_file_path = tmpdir.join('datafeed.id')
+    datafeed_id_file_content = get_resource_content("datafeed/datafeedId")
+    datafeed_id_file_path = tmpdir.join("datafeed.id")
     datafeed_id_file_path.write(datafeed_id_file_content)
 
-    datafeed_config = BdkDatafeedConfig({'idFilePath': str(tmpdir)})
+    datafeed_config = BdkDatafeedConfig({"idFilePath": str(tmpdir)})
     config.datafeed = datafeed_config
 
     datafeed_loop = auto_stopping_datafeed_loop_v1(datafeed_api, auth_session, config)
     datafeed_api.v4_datafeed_id_read_get.return_value = message_sent_event
     await datafeed_loop.start()
 
-    assert datafeed_loop.datafeed_id == '8e7c8672-220'
+    assert datafeed_loop.datafeed_id == "8e7c8672-220"
 
 
 @pytest.mark.asyncio
 async def test_retrieve_datafeed_id_from_unknown_path(datafeed_api, auth_session, config):
-    datafeed_config = BdkDatafeedConfig({'idFilePath': 'unknown_path'})
+    datafeed_config = BdkDatafeedConfig({"idFilePath": "unknown_path"})
     config.datafeed = datafeed_config
 
     datafeed_loop = auto_stopping_datafeed_loop_v1(datafeed_api, auth_session, config)
@@ -209,9 +209,9 @@ async def test_retrieve_datafeed_id_from_unknown_path(datafeed_api, auth_session
 
 @pytest.mark.asyncio
 async def test_retrieve_datafeed_id_from_empty_file(tmpdir, datafeed_api, auth_session, config):
-    datafeed_file_path = tmpdir.join('datafeed.id')
+    datafeed_file_path = tmpdir.join("datafeed.id")
 
-    datafeed_config = BdkDatafeedConfig({'idFilePath': str(datafeed_file_path)})
+    datafeed_config = BdkDatafeedConfig({"idFilePath": str(datafeed_file_path)})
     config.datafeed = datafeed_config
 
     datafeed_loop = auto_stopping_datafeed_loop_v1(datafeed_api, auth_session, config)
@@ -407,6 +407,6 @@ async def test_handle_event_list_with_none(datafeed_loop_with_listener, mock_lis
 
 @pytest.mark.asyncio
 async def test_handle_event_with_unknown_event_type(datafeed_loop_with_listener, mock_listener):
-    await datafeed_loop_with_listener.handle_v4_event_list([V4Event(type='unknown type')])
+    await datafeed_loop_with_listener.handle_v4_event_list([V4Event(type="unknown type")])
 
     mock_listener.assert_not_called()

--- a/tests/core/service/datafeed/datafeed_loop_v2_test.py
+++ b/tests/core/service/datafeed/datafeed_loop_v2_test.py
@@ -19,22 +19,22 @@ from symphony.bdk.gen.agent_model.v4_user import V4User
 from tests.utils.resource_utils import get_config_resource_filepath
 
 
-@pytest.fixture(name='auth_session')
+@pytest.fixture(name="auth_session")
 def fixture_auth_session():
     auth_session = AuthSession(None)
-    auth_session.session_token = 'session_token'
-    auth_session.key_manager_token = 'km_token'
+    auth_session.session_token = "session_token"
+    auth_session.key_manager_token = "km_token"
     return auth_session
 
 
-@pytest.fixture(name='config')
+@pytest.fixture(name="config")
 def fixture_config():
-    config = BdkConfigLoader.load_from_file(get_config_resource_filepath('config.yaml'))
-    config.datafeed.version = 'v2'
+    config = BdkConfigLoader.load_from_file(get_config_resource_filepath("config.yaml"))
+    config.datafeed.version = "v2"
     return config
 
 
-@pytest.fixture(name='datafeed_api')
+@pytest.fixture(name="datafeed_api")
 def fixtrue_datafeed_api():
     datafeed_api = MagicMock(DatafeedApi)
     datafeed_api.api_client = MagicMock(ApiClient)
@@ -45,22 +45,22 @@ def fixtrue_datafeed_api():
     return datafeed_api
 
 
-@pytest.fixture(name='mock_listener')
+@pytest.fixture(name="mock_listener")
 def fixture_mock_listener():
     return AsyncMock(wraps=RealTimeEventListener())
 
 
-@pytest.fixture(name='initiator')
+@pytest.fixture(name="initiator")
 def fixture_initiator():
-    return V4Initiator(user=V4User(username='username'))
+    return V4Initiator(user=V4User(username="username"))
 
 
-@pytest.fixture(name='message_sent_event')
+@pytest.fixture(name="message_sent_event")
 def fixture_message_sent_event(initiator):
     class EventsMock:
         def __init__(self, individual_event):
             self.events = [individual_event]
-            self.ack_id = 'ack_id'
+            self.ack_id = "ack_id"
 
     v4_event = V4Event(type=RealTimeEvent.MESSAGESENT.name,
                        payload=V4Payload(message_sent=V4MessageSent()),
@@ -69,7 +69,7 @@ def fixture_message_sent_event(initiator):
     return event
 
 
-@pytest.fixture(name='datafeed_loop')
+@pytest.fixture(name="datafeed_loop")
 def fixture_datafeed_loop(datafeed_api, auth_session, config):
     datafeed_loop = DatafeedLoopV2(datafeed_api, auth_session, config)
 
@@ -85,90 +85,90 @@ def fixture_datafeed_loop(datafeed_api, auth_session, config):
 @pytest.mark.asyncio
 async def test_start(datafeed_loop, datafeed_api, message_sent_event):
     datafeed_api.list_datafeed.return_value = []
-    datafeed_api.create_datafeed.return_value = Datafeed(id='test_id')
+    datafeed_api.create_datafeed.return_value = Datafeed(id="test_id")
     datafeed_api.read_datafeed.return_value = message_sent_event
 
     await datafeed_loop.start()
 
     datafeed_api.list_datafeed.assert_called_with(
-        session_token='session_token',
-        key_manager_token='km_token'
+        session_token="session_token",
+        key_manager_token="km_token"
     )
     datafeed_api.create_datafeed.assert_called_with(
-        session_token='session_token',
-        key_manager_token='km_token'
+        session_token="session_token",
+        key_manager_token="km_token"
     )
     datafeed_api.read_datafeed.assert_called_with(
-        session_token='session_token',
-        key_manager_token='km_token',
-        datafeed_id='test_id',
-        ack_id=AckId(ack_id='')
+        session_token="session_token",
+        key_manager_token="km_token",
+        datafeed_id="test_id",
+        ack_id=AckId(ack_id="")
     )
 
-    assert datafeed_loop._datafeed_id == 'test_id'
-    assert datafeed_loop._ack_id == 'ack_id'
+    assert datafeed_loop._datafeed_id == "test_id"
+    assert datafeed_loop._ack_id == "ack_id"
 
 
 @pytest.mark.asyncio
 async def test_start_datafeed_exist(datafeed_loop, datafeed_api, message_sent_event):
-    datafeed_api.list_datafeed.return_value = [Datafeed(id='test_id_exist')]
+    datafeed_api.list_datafeed.return_value = [Datafeed(id="test_id_exist")]
     datafeed_api.read_datafeed.return_value = message_sent_event
 
     await datafeed_loop.start()
 
     datafeed_api.list_datafeed.assert_called_with(
-        session_token='session_token',
-        key_manager_token='km_token'
+        session_token="session_token",
+        key_manager_token="km_token"
     )
     datafeed_api.read_datafeed.assert_called_with(
-        session_token='session_token',
-        key_manager_token='km_token',
-        datafeed_id='test_id_exist',
-        ack_id=AckId(ack_id='')
+        session_token="session_token",
+        key_manager_token="km_token",
+        datafeed_id="test_id_exist",
+        ack_id=AckId(ack_id="")
     )
 
-    assert datafeed_loop._datafeed_id == 'test_id_exist'
-    assert datafeed_loop._ack_id == 'ack_id'
+    assert datafeed_loop._datafeed_id == "test_id_exist"
+    assert datafeed_loop._ack_id == "ack_id"
 
 
 @pytest.mark.asyncio
 async def test_start_datafeed_stale_datafeed(datafeed_loop, datafeed_api, message_sent_event):
-    datafeed_api.list_datafeed.return_value = [Datafeed(id='fault_datafeed_id')]
-    datafeed_api.create_datafeed.return_value = Datafeed(id='test_id')
+    datafeed_api.list_datafeed.return_value = [Datafeed(id="fault_datafeed_id")]
+    datafeed_api.create_datafeed.return_value = Datafeed(id="test_id")
     datafeed_api.read_datafeed.side_effect = [ApiException(400), message_sent_event]
 
     await datafeed_loop.start()
 
     datafeed_api.list_datafeed.assert_called_with(
-        session_token='session_token',
-        key_manager_token='km_token'
+        session_token="session_token",
+        key_manager_token="km_token"
     )
 
     datafeed_api.delete_datafeed.assert_called_with(
-        session_token='session_token',
-        key_manager_token='km_token',
-        datafeed_id='fault_datafeed_id'
+        session_token="session_token",
+        key_manager_token="km_token",
+        datafeed_id="fault_datafeed_id"
     )
 
     datafeed_api.create_datafeed.assert_called_with(
-        session_token='session_token',
-        key_manager_token='km_token'
+        session_token="session_token",
+        key_manager_token="km_token"
     )
 
     datafeed_api.read_datafeed.assert_has_calls([
         call(
-            session_token='session_token',
-            key_manager_token='km_token',
-            datafeed_id='fault_datafeed_id',
-            ack_id=AckId(ack_id='')
+            session_token="session_token",
+            key_manager_token="km_token",
+            datafeed_id="fault_datafeed_id",
+            ack_id=AckId(ack_id="")
         ),
         call(
-            session_token='session_token',
-            key_manager_token='km_token',
-            datafeed_id='test_id',
-            ack_id=AckId(ack_id='')
+            session_token="session_token",
+            key_manager_token="km_token",
+            datafeed_id="test_id",
+            ack_id=AckId(ack_id="")
         )
     ])
 
-    assert datafeed_loop._datafeed_id == 'test_id'
-    assert datafeed_loop._ack_id == 'ack_id'
+    assert datafeed_loop._datafeed_id == "test_id"
+    assert datafeed_loop._ack_id == "ack_id"

--- a/tests/core/service/health/health_service_test.py
+++ b/tests/core/service/health/health_service_test.py
@@ -1,88 +1,87 @@
 from unittest.mock import MagicMock, AsyncMock
 import pytest
 
-from symphony.bdk.gen import ApiException
-from tests.utils.resource_utils import object_from_json_relative_path
-
 from symphony.bdk.core.service.health.health_service import HealthService
-
+from symphony.bdk.gen import ApiException
 from symphony.bdk.gen.agent_api.system_api import SystemApi
 from symphony.bdk.gen.agent_api.signals_api import SignalsApi
 
+from tests.utils.resource_utils import object_from_json_relative_path
 
-@pytest.fixture()
-def mocked_system_api_client():
+
+@pytest.fixture(name='system_api_client')
+def fixture_system_api_client():
     api_client = MagicMock(SystemApi)
     api_client.v3_health = AsyncMock()
     api_client.v3_extended_health = AsyncMock()
     return api_client
 
 
-@pytest.fixture()
-def mocked_signals_api_client():
+@pytest.fixture(name='signals_api_client')
+def fixture_signals_api_client():
     api_client = MagicMock(SignalsApi)
     api_client.v1_info_get = AsyncMock()
     return api_client
 
 
-@pytest.fixture()
-def health_service(mocked_system_api_client, mocked_signals_api_client):
-    return HealthService(mocked_system_api_client, mocked_signals_api_client)
+@pytest.fixture(name='health_service')
+def fixture_health_service(system_api_client, signals_api_client):
+    return HealthService(system_api_client, signals_api_client)
 
 
 @pytest.mark.asyncio
-async def test_health_check(health_service, mocked_system_api_client):
-    mocked_system_api_client.v3_health.return_value = object_from_json_relative_path(
-        "health_response/health_check.json")
+async def test_health_check(health_service, system_api_client):
+    system_api_client.v3_health.return_value = object_from_json_relative_path(
+        'health_response/health_check.json')
 
     health = await health_service.health_check()
 
-    assert health.status == "UP"
+    assert health.status == 'UP'
 
 
 @pytest.mark.asyncio
-async def test_health_check_failed(health_service, mocked_system_api_client):
-    mocked_system_api_client.v3_health.side_effect = ApiException(400)
+async def test_health_check_failed(health_service, system_api_client):
+    system_api_client.v3_health.side_effect = ApiException(400)
 
     with pytest.raises(ApiException):
         await health_service.health_check()
 
 
 @pytest.mark.asyncio
-async def test_health_check_extended(health_service, mocked_system_api_client):
-    mocked_system_api_client.v3_extended_health.return_value = object_from_json_relative_path(
-        "health_response/health_check_extended.json")
+async def test_health_check_extended(health_service, system_api_client):
+    system_api_client.v3_extended_health.return_value = object_from_json_relative_path(
+        'health_response/health_check_extended.json')
     health = await health_service.health_check_extended()
 
-    assert health.status == "UP"
-    assert health.services.pod.version == "1.57.0"
-    assert health.services.datafeed.status == "UP"
-    assert health.users.agentservice.status == "UP"
+    assert health.status == 'UP'
+    assert health.services.pod.version == '1.57.0'
+    assert health.services.datafeed.status == 'UP'
+    assert health.users.agentservice.status == 'UP'
 
 
 @pytest.mark.asyncio
-async def test_health_check_extended_failed(health_service, mocked_system_api_client):
-    mocked_system_api_client.v3_extended_health.side_effect = ApiException(400)
+async def test_health_check_extended_failed(health_service, system_api_client):
+    system_api_client.v3_extended_health.side_effect = ApiException(400)
 
     with pytest.raises(ApiException):
         await health_service.health_check_extended()
 
 
 @pytest.mark.asyncio
-async def test_get_agent_info(health_service, mocked_signals_api_client):
-    mocked_signals_api_client.v1_info_get.return_value = object_from_json_relative_path(
-        "health_response/agent_info.json")
+async def test_get_agent_info(health_service, signals_api_client):
+    signals_api_client.v1_info_get.return_value = object_from_json_relative_path(
+        'health_response/agent_info.json')
 
     agent_info = await health_service.get_agent_info()
 
-    assert agent_info.hostname == "agent-75...4b6"
-    assert agent_info.ipAddress == "22.222.222.22"
+    assert agent_info.hostname == 'agent-75...4b6'
+    assert agent_info.ipAddress == '22.222.222.22'
     assert agent_info.onPrem
 
 
 @pytest.mark.asyncio
-async def test_get_agent_info_failed(health_service, mocked_signals_api_client):
-    mocked_signals_api_client.v1_info_get.side_effect = ApiException(400)
+async def test_get_agent_info_failed(health_service, signals_api_client):
+    signals_api_client.v1_info_get.side_effect = ApiException(400)
 
     with pytest.raises(ApiException):
         await health_service.get_agent_info()

--- a/tests/core/service/health/health_service_test.py
+++ b/tests/core/service/health/health_service_test.py
@@ -9,79 +9,79 @@ from symphony.bdk.gen.agent_api.signals_api import SignalsApi
 from tests.utils.resource_utils import object_from_json_relative_path
 
 
-@pytest.fixture(name='system_api_client')
-def fixture_system_api_client():
+@pytest.fixture(name="mocked_system_api_client")
+def fixture_mocked_system_api_client():
     api_client = MagicMock(SystemApi)
     api_client.v3_health = AsyncMock()
     api_client.v3_extended_health = AsyncMock()
     return api_client
 
 
-@pytest.fixture(name='signals_api_client')
-def fixture_signals_api_client():
+@pytest.fixture(name="mocked_signals_api_client")
+def fixture_mocked_signals_api_client():
     api_client = MagicMock(SignalsApi)
     api_client.v1_info_get = AsyncMock()
     return api_client
 
 
-@pytest.fixture(name='health_service')
-def fixture_health_service(system_api_client, signals_api_client):
-    return HealthService(system_api_client, signals_api_client)
+@pytest.fixture(name="health_service")
+def fixture_health_service(mocked_system_api_client, mocked_signals_api_client):
+    return HealthService(mocked_system_api_client, mocked_signals_api_client)
 
 
 @pytest.mark.asyncio
-async def test_health_check(health_service, system_api_client):
-    system_api_client.v3_health.return_value = object_from_json_relative_path(
-        'health_response/health_check.json')
+async def test_health_check(health_service, mocked_system_api_client):
+    mocked_system_api_client.v3_health.return_value = object_from_json_relative_path(
+        "health_response/health_check.json")
 
     health = await health_service.health_check()
 
-    assert health.status == 'UP'
+    assert health.status == "UP"
 
 
 @pytest.mark.asyncio
-async def test_health_check_failed(health_service, system_api_client):
-    system_api_client.v3_health.side_effect = ApiException(400)
+async def test_health_check_failed(health_service, mocked_system_api_client):
+    mocked_system_api_client.v3_health.side_effect = ApiException(400)
 
     with pytest.raises(ApiException):
         await health_service.health_check()
 
 
 @pytest.mark.asyncio
-async def test_health_check_extended(health_service, system_api_client):
-    system_api_client.v3_extended_health.return_value = object_from_json_relative_path(
-        'health_response/health_check_extended.json')
+async def test_health_check_extended(health_service, mocked_system_api_client):
+    mocked_system_api_client.v3_extended_health.return_value = object_from_json_relative_path(
+        "health_response/health_check_extended.json")
     health = await health_service.health_check_extended()
 
-    assert health.status == 'UP'
-    assert health.services.pod.version == '1.57.0'
-    assert health.services.datafeed.status == 'UP'
-    assert health.users.agentservice.status == 'UP'
+    assert health.status == "UP"
+    assert health.services.pod.version == "1.57.0"
+    assert health.services.datafeed.status == "UP"
+    assert health.users.agentservice.status == "UP"
 
 
 @pytest.mark.asyncio
-async def test_health_check_extended_failed(health_service, system_api_client):
-    system_api_client.v3_extended_health.side_effect = ApiException(400)
+async def test_health_check_extended_failed(health_service, mocked_system_api_client):
+    mocked_system_api_client.v3_extended_health.side_effect = ApiException(400)
 
     with pytest.raises(ApiException):
         await health_service.health_check_extended()
 
 
 @pytest.mark.asyncio
-async def test_get_agent_info(health_service, signals_api_client):
-    signals_api_client.v1_info_get.return_value = object_from_json_relative_path(
-        'health_response/agent_info.json')
+async def test_get_agent_info(health_service, mocked_signals_api_client):
+    mocked_signals_api_client.v1_info_get.return_value = object_from_json_relative_path(
+        "health_response/agent_info.json")
 
     agent_info = await health_service.get_agent_info()
 
-    assert agent_info.hostname == 'agent-75...4b6'
-    assert agent_info.ipAddress == '22.222.222.22'
+    assert agent_info.hostname == "agent-75...4b6"
+    assert agent_info.ipAddress == "22.222.222.22"
     assert agent_info.onPrem
 
 
 @pytest.mark.asyncio
-async def test_get_agent_info_failed(health_service, signals_api_client):
-    signals_api_client.v1_info_get.side_effect = ApiException(400)
+async def test_get_agent_info_failed(health_service, mocked_signals_api_client):
+    mocked_signals_api_client.v1_info_get.side_effect = ApiException(400)
 
     with pytest.raises(ApiException):
         await health_service.get_agent_info()

--- a/tests/core/service/message/message_service_test.py
+++ b/tests/core/service/message/message_service_test.py
@@ -16,68 +16,68 @@ from symphony.bdk.gen.pod_api.streams_api import StreamsApi
 from tests.utils.resource_utils import object_from_json_relative_path, object_from_json
 
 
-@pytest.fixture(name='auth_session')
+@pytest.fixture(name="auth_session")
 def fixture_auth_session():
     auth_session = AuthSession(None)
-    auth_session.session_token = 'session_token'
-    auth_session.key_manager_token = 'km_token'
+    auth_session.session_token = "session_token"
+    auth_session.key_manager_token = "km_token"
     return auth_session
 
 
-@pytest.fixture(name='api_client')
-def fixture_api_client():
+@pytest.fixture(name="mocked_api_client")
+def fixture_mocked_api_client():
     api_client = MagicMock(ApiClient)
     api_client.call_api = AsyncMock()
     api_client.configuration = Configuration()
     return api_client
 
 
-@pytest.fixture(name='message_service')
-def fixture_message_service(api_client, auth_session):
+@pytest.fixture(name="message_service")
+def fixture_message_service(mocked_api_client, auth_session):
     service = MessageService(
-        MultiAttachmentsMessagesApi(api_client),
-        MessageApi(api_client),
-        MessageSuppressionApi(api_client),
-        StreamsApi(api_client),
-        PodApi(api_client),
-        AttachmentsApi(api_client),
-        DefaultApi(api_client),
+        MultiAttachmentsMessagesApi(mocked_api_client),
+        MessageApi(mocked_api_client),
+        MessageSuppressionApi(mocked_api_client),
+        StreamsApi(mocked_api_client),
+        PodApi(mocked_api_client),
+        AttachmentsApi(mocked_api_client),
+        DefaultApi(mocked_api_client),
         auth_session
     )
     return service
 
 
 @pytest.mark.asyncio
-async def test_list_messages(api_client, message_service):
-    api_client.call_api.return_value = object_from_json_relative_path('message_response/list_messages.json')
-    messages_list = await message_service.list_messages('stream_id')
+async def test_list_messages(mocked_api_client, message_service):
+    mocked_api_client.call_api.return_value = object_from_json_relative_path("message_response/list_messages.json")
+    messages_list = await message_service.list_messages("stream_id")
 
     assert len(messages_list) == 1
-    assert messages_list[0].messageId == 'test-message1'
+    assert messages_list[0].messageId == "test-message1"
 
 
 @pytest.mark.asyncio
-async def test_send_message(api_client, message_service):
-    api_client.call_api.return_value = object_from_json_relative_path('message_response/message.json')
-    message = await message_service.send_message('stream_id', 'test_message')
+async def test_send_message(mocked_api_client, message_service):
+    mocked_api_client.call_api.return_value = object_from_json_relative_path("message_response/message.json")
+    message = await message_service.send_message("stream_id", "test_message")
 
-    assert message.messageId == '-AANBHKtUC-2q6_0WSjBGX___pHnSfBKdA'
+    assert message.messageId == "-AANBHKtUC-2q6_0WSjBGX___pHnSfBKdA"
     assert message.user.userId == 7078106482890
 
 
 @pytest.mark.asyncio
-async def test_blast_message(api_client, message_service):
-    api_client.call_api.return_value = object_from_json_relative_path('message_response/blast_message.json')
-    blast_message = await message_service.blast_message(['stream_id1', 'stream_id2'], 'test_message')
+async def test_blast_message(mocked_api_client, message_service):
+    mocked_api_client.call_api.return_value = object_from_json_relative_path("message_response/blast_message.json")
+    blast_message = await message_service.blast_message(["stream_id1", "stream_id2"], "test_message")
 
     assert len(blast_message.messages) == 2
-    assert blast_message.messages[0].messageId == '-AANBHKtUC-2q6_0WSjBGX___pHnSfBKdA-1'
-    assert blast_message.messages[1].messageId == '-AANBHKtUC-2q6_0WSjBGX___pHnSfBKdA-2'
+    assert blast_message.messages[0].messageId == "-AANBHKtUC-2q6_0WSjBGX___pHnSfBKdA-1"
+    assert blast_message.messages[1].messageId == "-AANBHKtUC-2q6_0WSjBGX___pHnSfBKdA-2"
 
 
 @pytest.mark.asyncio
-async def test_import_message(api_client, message_service):
-    api_client.call_api.return_value = object_from_json(
+async def test_import_message(mocked_api_client, message_service):
+    mocked_api_client.call_api.return_value = object_from_json(
         '{"value": ['
         '   {'
         '       "messageId": "FjSY1y3L",  '
@@ -87,54 +87,54 @@ async def test_import_message(api_client, message_service):
         ']}')
 
     import_response = await message_service.import_messages([V4ImportedMessage(
-        message='test_message',
+        message="test_message",
         intended_message_timestamp=1433045622000,
         intended_message_from_user_id=7215545057281,
-        originating_system_id='fooChat',
-        stream_id='Z3oQRAZGTCNl5KjiUH2G1n___qr9lLT8dA'
+        originating_system_id="fooChat",
+        stream_id="Z3oQRAZGTCNl5KjiUH2G1n___qr9lLT8dA"
     )])
 
     assert len(import_response) == 1
-    assert import_response[0].messageId == 'FjSY1y3L'
-    assert import_response[0].originatingSystemId == 'AGENT_SDK'
+    assert import_response[0].messageId == "FjSY1y3L"
+    assert import_response[0].originatingSystemId == "AGENT_SDK"
 
 
 @pytest.mark.asyncio
-async def test_get_attachment(api_client, message_service):
-    api_client.call_api.return_value = 'attachment-string'
+async def test_get_attachment(mocked_api_client, message_service):
+    mocked_api_client.call_api.return_value = "attachment-string"
 
-    attachment = await message_service.get_attachment('stream-id', 'message-id', 'attachment-id')
+    attachment = await message_service.get_attachment("stream-id", "message-id", "attachment-id")
 
-    assert attachment == 'attachment-string'
+    assert attachment == "attachment-string"
 
 
 @pytest.mark.asyncio
-async def test_suppress_message(api_client, message_service):
-    api_client.call_api.return_value = object_from_json(
+async def test_suppress_message(mocked_api_client, message_service):
+    mocked_api_client.call_api.return_value = object_from_json(
         '{'
         '   "messageId": "test-message-id",'
         '   "suppressed": true,'
         '   "suppressionDate": 1461565603191'
         '}')
-    suppress_response = await message_service.suppress_message('test-message-id')
+    suppress_response = await message_service.suppress_message("test-message-id")
 
-    assert suppress_response.messageId == 'test-message-id'
+    assert suppress_response.messageId == "test-message-id"
     assert suppress_response.suppressionDate == 1461565603191
 
 
 @pytest.mark.asyncio
-async def test_get_message_status(api_client, message_service):
-    api_client.call_api.return_value = object_from_json_relative_path('message_response/message_status.json')
-    message_status = await message_service.get_message_status('test-message-id')
+async def test_get_message_status(mocked_api_client, message_service):
+    mocked_api_client.call_api.return_value = object_from_json_relative_path("message_response/message_status.json")
+    message_status = await message_service.get_message_status("test-message-id")
 
-    assert message_status.author.userId == '7078106103901'
+    assert message_status.author.userId == "7078106103901"
     assert len(message_status.read) == 2
     assert len(message_status.sent) == 1
 
 
 @pytest.mark.asyncio
-async def test_get_attachment_types(api_client, message_service):
-    api_client.call_api.return_value = object_from_json(
+async def test_get_attachment_types(mocked_api_client, message_service):
+    mocked_api_client.call_api.return_value = object_from_json(
         '{"value": ['
         '   ".bmp",'
         '   ".doc",'
@@ -145,42 +145,42 @@ async def test_get_attachment_types(api_client, message_service):
     attachment_types = await message_service.get_attachment_types()
 
     assert len(attachment_types) == 4
-    assert attachment_types[0] == '.bmp'
+    assert attachment_types[0] == ".bmp"
 
 
 @pytest.mark.asyncio
-async def test_get_message(api_client, message_service):
-    api_client.call_api.return_value = object_from_json_relative_path('message_response/message.json')
-    message = await message_service.get_message('-AANBHKtUC-2q6_0WSjBGX___pHnSfBKdA')
+async def test_get_message(mocked_api_client, message_service):
+    mocked_api_client.call_api.return_value = object_from_json_relative_path("message_response/message.json")
+    message = await message_service.get_message("-AANBHKtUC-2q6_0WSjBGX___pHnSfBKdA")
 
-    assert message.messageId == '-AANBHKtUC-2q6_0WSjBGX___pHnSfBKdA'
+    assert message.messageId == "-AANBHKtUC-2q6_0WSjBGX___pHnSfBKdA"
     assert message.timestamp == 1572372615137
     assert message.user.userId == 7078106482890
 
 
 @pytest.mark.asyncio
-async def test_list_attachments(api_client, message_service):
-    api_client.call_api.return_value = object_from_json_relative_path('message_response/list_attachments.json')
-    attachments = await message_service.list_attachments('stream_id')
+async def test_list_attachments(mocked_api_client, message_service):
+    mocked_api_client.call_api.return_value = object_from_json_relative_path("message_response/list_attachments.json")
+    attachments = await message_service.list_attachments("stream_id")
 
     assert len(attachments) == 2
-    assert attachments[0].messageId == 'PYLHNm/1K6p...peOpj+FbQ'
-    assert attachments[1].fileId == 'internal_14362370637825%2FeM6zGAILWFakDObCwMANrw%3D%3D'
+    assert attachments[0].messageId == "PYLHNm/1K6p...peOpj+FbQ"
+    assert attachments[1].fileId == "internal_14362370637825%2FeM6zGAILWFakDObCwMANrw%3D%3D"
 
 
 @pytest.mark.asyncio
-async def test_message_receipts(api_client, message_service):
-    api_client.call_api.return_value = object_from_json_relative_path('message_response/message_receipts.json')
-    message_receipts = await message_service.list_message_receipts('test-message-id')
+async def test_message_receipts(mocked_api_client, message_service):
+    mocked_api_client.call_api.return_value = object_from_json_relative_path("message_response/message_receipts.json")
+    message_receipts = await message_service.list_message_receipts("test-message-id")
 
     assert message_receipts.creator.id == 7215545058329
-    assert message_receipts.stream.id == 'lFpyw0ATFmji+Cc/cSzbk3///pZkWpe1dA=='
+    assert message_receipts.stream.id == "lFpyw0ATFmji+Cc/cSzbk3///pZkWpe1dA=="
     assert message_receipts.MessageReceiptDetail[0].user.id == 7215545058329
 
 
 @pytest.mark.asyncio
-async def test_get_message_relationships(api_client, message_service):
-    api_client.call_api.return_value = object_from_json(
+async def test_get_message_relationships(mocked_api_client, message_service):
+    mocked_api_client.call_api.return_value = object_from_json(
         '{ '
         '   "messageId": "TYgOZ65dVsu3SeK7u2YdfH///o6fzBu",'
         '   "parent": {'
@@ -192,8 +192,8 @@ async def test_get_message_relationships(api_client, message_service):
         '   "formReplies": []'
         '}'
     )
-    message_relationships = await message_service.get_message_relationships('TYgOZ65dVsu3SeK7u2YdfH///o6fzBu')
+    message_relationships = await message_service.get_message_relationships("TYgOZ65dVsu3SeK7u2YdfH///o6fzBu")
 
-    assert message_relationships.messageId == 'TYgOZ65dVsu3SeK7u2YdfH///o6fzBu'
-    assert message_relationships.parent.messageId == '/rbLQW5UHKZffM0FlLO2rn///o6vTck'
-    assert message_relationships.parent.relationshipType == 'REPLY'
+    assert message_relationships.messageId == "TYgOZ65dVsu3SeK7u2YdfH///o6fzBu"
+    assert message_relationships.parent.messageId == "/rbLQW5UHKZffM0FlLO2rn///o6vTck"
+    assert message_relationships.parent.relationshipType == "REPLY"

--- a/tests/core/service/message/message_service_test.py
+++ b/tests/core/service/message/message_service_test.py
@@ -16,68 +16,68 @@ from symphony.bdk.gen.pod_api.streams_api import StreamsApi
 from tests.utils.resource_utils import object_from_json_relative_path, object_from_json
 
 
-@pytest.fixture()
-def auth_session():
+@pytest.fixture(name='auth_session')
+def fixture_auth_session():
     auth_session = AuthSession(None)
     auth_session.session_token = 'session_token'
     auth_session.key_manager_token = 'km_token'
     return auth_session
 
 
-@pytest.fixture()
-def mocked_api_client():
+@pytest.fixture(name='api_client')
+def fixture_api_client():
     api_client = MagicMock(ApiClient)
     api_client.call_api = AsyncMock()
     api_client.configuration = Configuration()
     return api_client
 
 
-@pytest.fixture()
-def message_service(mocked_api_client, auth_session):
+@pytest.fixture(name='message_service')
+def fixture_message_service(api_client, auth_session):
     service = MessageService(
-        MultiAttachmentsMessagesApi(mocked_api_client),
-        MessageApi(mocked_api_client),
-        MessageSuppressionApi(mocked_api_client),
-        StreamsApi(mocked_api_client),
-        PodApi(mocked_api_client),
-        AttachmentsApi(mocked_api_client),
-        DefaultApi(mocked_api_client),
+        MultiAttachmentsMessagesApi(api_client),
+        MessageApi(api_client),
+        MessageSuppressionApi(api_client),
+        StreamsApi(api_client),
+        PodApi(api_client),
+        AttachmentsApi(api_client),
+        DefaultApi(api_client),
         auth_session
     )
     return service
 
 
 @pytest.mark.asyncio
-async def test_list_messages(mocked_api_client, message_service):
-    mocked_api_client.call_api.return_value = object_from_json_relative_path("message_response/list_messages.json")
-    messages_list = await message_service.list_messages("stream_id")
+async def test_list_messages(api_client, message_service):
+    api_client.call_api.return_value = object_from_json_relative_path('message_response/list_messages.json')
+    messages_list = await message_service.list_messages('stream_id')
 
     assert len(messages_list) == 1
-    assert messages_list[0].messageId == "test-message1"
+    assert messages_list[0].messageId == 'test-message1'
 
 
 @pytest.mark.asyncio
-async def test_send_message(mocked_api_client, message_service):
-    mocked_api_client.call_api.return_value = object_from_json_relative_path("message_response/message.json")
-    message = await message_service.send_message("stream_id", "test_message")
+async def test_send_message(api_client, message_service):
+    api_client.call_api.return_value = object_from_json_relative_path('message_response/message.json')
+    message = await message_service.send_message('stream_id', 'test_message')
 
-    assert message.messageId == "-AANBHKtUC-2q6_0WSjBGX___pHnSfBKdA"
+    assert message.messageId == '-AANBHKtUC-2q6_0WSjBGX___pHnSfBKdA'
     assert message.user.userId == 7078106482890
 
 
 @pytest.mark.asyncio
-async def test_blast_message(mocked_api_client, message_service):
-    mocked_api_client.call_api.return_value = object_from_json_relative_path("message_response/blast_message.json")
-    blast_message = await message_service.blast_message(["stream_id1", "stream_id2"], "test_message")
+async def test_blast_message(api_client, message_service):
+    api_client.call_api.return_value = object_from_json_relative_path('message_response/blast_message.json')
+    blast_message = await message_service.blast_message(['stream_id1', 'stream_id2'], 'test_message')
 
     assert len(blast_message.messages) == 2
-    assert blast_message.messages[0].messageId == "-AANBHKtUC-2q6_0WSjBGX___pHnSfBKdA-1"
-    assert blast_message.messages[1].messageId == "-AANBHKtUC-2q6_0WSjBGX___pHnSfBKdA-2"
+    assert blast_message.messages[0].messageId == '-AANBHKtUC-2q6_0WSjBGX___pHnSfBKdA-1'
+    assert blast_message.messages[1].messageId == '-AANBHKtUC-2q6_0WSjBGX___pHnSfBKdA-2'
 
 
 @pytest.mark.asyncio
-async def test_import_message(mocked_api_client, message_service):
-    mocked_api_client.call_api.return_value = object_from_json(
+async def test_import_message(api_client, message_service):
+    api_client.call_api.return_value = object_from_json(
         '{"value": ['
         '   {'
         '       "messageId": "FjSY1y3L",  '
@@ -87,30 +87,30 @@ async def test_import_message(mocked_api_client, message_service):
         ']}')
 
     import_response = await message_service.import_messages([V4ImportedMessage(
-        message="test_message",
+        message='test_message',
         intended_message_timestamp=1433045622000,
         intended_message_from_user_id=7215545057281,
-        originating_system_id="fooChat",
-        stream_id="Z3oQRAZGTCNl5KjiUH2G1n___qr9lLT8dA"
+        originating_system_id='fooChat',
+        stream_id='Z3oQRAZGTCNl5KjiUH2G1n___qr9lLT8dA'
     )])
 
     assert len(import_response) == 1
-    assert import_response[0].messageId == "FjSY1y3L"
-    assert import_response[0].originatingSystemId == "AGENT_SDK"
+    assert import_response[0].messageId == 'FjSY1y3L'
+    assert import_response[0].originatingSystemId == 'AGENT_SDK'
 
 
 @pytest.mark.asyncio
-async def test_get_attachment(mocked_api_client, message_service):
-    mocked_api_client.call_api.return_value = "attachment-string"
+async def test_get_attachment(api_client, message_service):
+    api_client.call_api.return_value = 'attachment-string'
 
-    attachment = await message_service.get_attachment("stream-id", "message-id", "attachment-id")
+    attachment = await message_service.get_attachment('stream-id', 'message-id', 'attachment-id')
 
-    assert attachment == "attachment-string"
+    assert attachment == 'attachment-string'
 
 
 @pytest.mark.asyncio
-async def test_suppress_message(mocked_api_client, message_service):
-    mocked_api_client.call_api.return_value = object_from_json(
+async def test_suppress_message(api_client, message_service):
+    api_client.call_api.return_value = object_from_json(
         '{'
         '   "messageId": "test-message-id",'
         '   "suppressed": true,'
@@ -118,14 +118,14 @@ async def test_suppress_message(mocked_api_client, message_service):
         '}')
     suppress_response = await message_service.suppress_message('test-message-id')
 
-    assert suppress_response.messageId == "test-message-id"
+    assert suppress_response.messageId == 'test-message-id'
     assert suppress_response.suppressionDate == 1461565603191
 
 
 @pytest.mark.asyncio
-async def test_get_message_status(mocked_api_client, message_service):
-    mocked_api_client.call_api.return_value = object_from_json_relative_path("message_response/message_status.json")
-    message_status = await message_service.get_message_status("test-message-id")
+async def test_get_message_status(api_client, message_service):
+    api_client.call_api.return_value = object_from_json_relative_path('message_response/message_status.json')
+    message_status = await message_service.get_message_status('test-message-id')
 
     assert message_status.author.userId == '7078106103901'
     assert len(message_status.read) == 2
@@ -133,8 +133,8 @@ async def test_get_message_status(mocked_api_client, message_service):
 
 
 @pytest.mark.asyncio
-async def test_get_attachment_types(mocked_api_client, message_service):
-    mocked_api_client.call_api.return_value = object_from_json(
+async def test_get_attachment_types(api_client, message_service):
+    api_client.call_api.return_value = object_from_json(
         '{"value": ['
         '   ".bmp",'
         '   ".doc",'
@@ -149,38 +149,38 @@ async def test_get_attachment_types(mocked_api_client, message_service):
 
 
 @pytest.mark.asyncio
-async def test_get_message(mocked_api_client, message_service):
-    mocked_api_client.call_api.return_value = object_from_json_relative_path("message_response/message.json")
-    message = await message_service.get_message("-AANBHKtUC-2q6_0WSjBGX___pHnSfBKdA")
+async def test_get_message(api_client, message_service):
+    api_client.call_api.return_value = object_from_json_relative_path('message_response/message.json')
+    message = await message_service.get_message('-AANBHKtUC-2q6_0WSjBGX___pHnSfBKdA')
 
-    assert message.messageId == "-AANBHKtUC-2q6_0WSjBGX___pHnSfBKdA"
+    assert message.messageId == '-AANBHKtUC-2q6_0WSjBGX___pHnSfBKdA'
     assert message.timestamp == 1572372615137
     assert message.user.userId == 7078106482890
 
 
 @pytest.mark.asyncio
-async def test_list_attachments(mocked_api_client, message_service):
-    mocked_api_client.call_api.return_value = object_from_json_relative_path("message_response/list_attachments.json")
-    attachments = await message_service.list_attachments("stream_id")
+async def test_list_attachments(api_client, message_service):
+    api_client.call_api.return_value = object_from_json_relative_path('message_response/list_attachments.json')
+    attachments = await message_service.list_attachments('stream_id')
 
     assert len(attachments) == 2
-    assert attachments[0].messageId == "PYLHNm/1K6p...peOpj+FbQ"
-    assert attachments[1].fileId == "internal_14362370637825%2FeM6zGAILWFakDObCwMANrw%3D%3D"
+    assert attachments[0].messageId == 'PYLHNm/1K6p...peOpj+FbQ'
+    assert attachments[1].fileId == 'internal_14362370637825%2FeM6zGAILWFakDObCwMANrw%3D%3D'
 
 
 @pytest.mark.asyncio
-async def test_message_receipts(mocked_api_client, message_service):
-    mocked_api_client.call_api.return_value = object_from_json_relative_path("message_response/message_receipts.json")
-    message_receipts = await message_service.list_message_receipts("test-message-id")
+async def test_message_receipts(api_client, message_service):
+    api_client.call_api.return_value = object_from_json_relative_path('message_response/message_receipts.json')
+    message_receipts = await message_service.list_message_receipts('test-message-id')
 
     assert message_receipts.creator.id == 7215545058329
-    assert message_receipts.stream.id == "lFpyw0ATFmji+Cc/cSzbk3///pZkWpe1dA=="
+    assert message_receipts.stream.id == 'lFpyw0ATFmji+Cc/cSzbk3///pZkWpe1dA=='
     assert message_receipts.MessageReceiptDetail[0].user.id == 7215545058329
 
 
 @pytest.mark.asyncio
-async def test_get_message_relationships(mocked_api_client, message_service):
-    mocked_api_client.call_api.return_value = object_from_json(
+async def test_get_message_relationships(api_client, message_service):
+    api_client.call_api.return_value = object_from_json(
         '{ '
         '   "messageId": "TYgOZ65dVsu3SeK7u2YdfH///o6fzBu",'
         '   "parent": {'
@@ -192,8 +192,8 @@ async def test_get_message_relationships(mocked_api_client, message_service):
         '   "formReplies": []'
         '}'
     )
-    message_relationships = await message_service.get_message_relationships("TYgOZ65dVsu3SeK7u2YdfH///o6fzBu")
+    message_relationships = await message_service.get_message_relationships('TYgOZ65dVsu3SeK7u2YdfH///o6fzBu')
 
-    assert message_relationships.messageId == "TYgOZ65dVsu3SeK7u2YdfH///o6fzBu"
-    assert message_relationships.parent.messageId == "/rbLQW5UHKZffM0FlLO2rn///o6vTck"
-    assert message_relationships.parent.relationshipType == "REPLY"
+    assert message_relationships.messageId == 'TYgOZ65dVsu3SeK7u2YdfH///o6fzBu'
+    assert message_relationships.parent.messageId == '/rbLQW5UHKZffM0FlLO2rn///o6vTck'
+    assert message_relationships.parent.relationshipType == 'REPLY'

--- a/tests/core/service/presence/presence_service_test.py
+++ b/tests/core/service/presence/presence_service_test.py
@@ -8,16 +8,16 @@ from symphony.bdk.core.service.presence.presence_service import PresenceService,
 from tests.utils.resource_utils import object_from_json_relative_path
 
 
-@pytest.fixture(name='auth_session')
+@pytest.fixture(name="auth_session")
 def fixture_auth_session():
     bot_session = AuthSession(None)
-    bot_session.session_token = 'session_token'
-    bot_session.key_manager_token = 'km_token'
+    bot_session.session_token = "session_token"
+    bot_session.key_manager_token = "km_token"
     return bot_session
 
 
-@pytest.fixture(name='presence_api_client')
-def fixture_presence_api_client():
+@pytest.fixture(name="mocked_presence_api_client")
+def fixture_mocked_presence_api_client():
     api_client = MagicMock(PresenceApi)
     api_client.v2_user_presence_get = AsyncMock()
     api_client.v2_users_presence_get = AsyncMock()
@@ -31,168 +31,168 @@ def fixture_presence_api_client():
     return api_client
 
 
-@pytest.fixture(name='presence_service')
-def fixture_presence_service(presence_api_client, auth_session):
-    return PresenceService(presence_api_client, auth_session)
+@pytest.fixture(name="presence_service")
+def fixture_presence_service(mocked_presence_api_client, auth_session):
+    return PresenceService(mocked_presence_api_client, auth_session)
 
 
-@pytest.fixture(name='presence_payload')
+@pytest.fixture(name="presence_payload")
 def fixture_presence_payload():
-    return object_from_json_relative_path('presence_response/presence_payload.json')
+    return object_from_json_relative_path("presence_response/presence_payload.json")
 
 
 @pytest.mark.asyncio
-async def test_get_presence(presence_service, presence_api_client, presence_payload):
-    presence_api_client.v2_user_presence_get.return_value = presence_payload.user_presence
+async def test_get_presence(presence_service, mocked_presence_api_client, presence_payload):
+    mocked_presence_api_client.v2_user_presence_get.return_value = presence_payload.user_presence
 
     presence = await presence_service.get_presence()
 
-    assert presence.category == 'AVAILABLE'
+    assert presence.category == "AVAILABLE"
     assert presence.userId == 14568529068038
 
 
 @pytest.mark.asyncio
-async def test_get_presence_failed(presence_service, presence_api_client):
-    presence_api_client.v2_user_presence_get.side_effect = ApiException(400)
+async def test_get_presence_failed(presence_service, mocked_presence_api_client):
+    mocked_presence_api_client.v2_user_presence_get.side_effect = ApiException(400)
 
     with pytest.raises(ApiException):
         await presence_service.get_presence()
 
 
 @pytest.mark.asyncio
-async def test_get_all_presence(presence_service, presence_api_client, presence_payload):
-    presence_api_client.v2_users_presence_get.return_value = presence_payload.multiple_presences
+async def test_get_all_presence(presence_service, mocked_presence_api_client, presence_payload):
+    mocked_presence_api_client.v2_users_presence_get.return_value = presence_payload.multiple_presences
 
     presence_list = await presence_service.get_all_presence(1234, 5000)
 
     assert len(presence_list) == 2
     assert presence_list[0].userId == 14568529068038
-    assert presence_list[0].category == 'AVAILABLE'
+    assert presence_list[0].category == "AVAILABLE"
     assert presence_list[0].timestamp == 1533928483800
     assert presence_list[1].userId == 974217539631
-    assert presence_list[1].category == 'OFFLINE'
+    assert presence_list[1].category == "OFFLINE"
 
 
 @pytest.mark.asyncio
-async def test_get_all_presence_failed(presence_service, presence_api_client):
-    presence_api_client.v2_users_presence_get.side_effect = ApiException(400)
+async def test_get_all_presence_failed(presence_service, mocked_presence_api_client):
+    mocked_presence_api_client.v2_users_presence_get.side_effect = ApiException(400)
 
     with pytest.raises(ApiException):
         await presence_service.get_all_presence(1234, 5000)
 
 
 @pytest.mark.asyncio
-async def test_get_user_presence(presence_service, presence_api_client, presence_payload):
-    presence_api_client.v3_user_uid_presence_get.return_value = presence_payload.user_presence
+async def test_get_user_presence(presence_service, mocked_presence_api_client, presence_payload):
+    mocked_presence_api_client.v3_user_uid_presence_get.return_value = presence_payload.user_presence
 
     presence = await presence_service.get_user_presence(1234, True)
 
     assert presence.userId == 14568529068038
-    assert presence.category == 'AVAILABLE'
+    assert presence.category == "AVAILABLE"
 
 
 @pytest.mark.asyncio
-async def test_get_user_presence_failed(presence_service, presence_api_client):
-    presence_api_client.v3_user_uid_presence_get.side_effect = ApiException(400)
+async def test_get_user_presence_failed(presence_service, mocked_presence_api_client):
+    mocked_presence_api_client.v3_user_uid_presence_get.side_effect = ApiException(400)
 
     with pytest.raises(ApiException):
         await presence_service.get_user_presence(1234, True)
 
 
 @pytest.mark.asyncio
-async def test_external_presence_interest(presence_service, presence_api_client):
+async def test_external_presence_interest(presence_service, mocked_presence_api_client):
     uid_list = [1234]
     await presence_service.external_presence_interest(uid_list)
-    presence_api_client.v1_user_presence_register_post.assert_called_once_with(session_token='session_token',
+    mocked_presence_api_client.v1_user_presence_register_post.assert_called_once_with(session_token="session_token",
                                                                                       uid_list=uid_list)
 
 
 @pytest.mark.asyncio
-async def test_external_presence_interest_failed(presence_service, presence_api_client):
-    presence_api_client.v1_user_presence_register_post.side_effect = ApiException(400)
+async def test_external_presence_interest_failed(presence_service, mocked_presence_api_client):
+    mocked_presence_api_client.v1_user_presence_register_post.side_effect = ApiException(400)
     uid_list = [1234]
     with pytest.raises(ApiException):
         await presence_service.external_presence_interest(uid_list)
 
 
 @pytest.mark.asyncio
-async def test_set_presence(presence_service, presence_api_client, presence_payload):
-    presence_api_client.v2_user_presence_post.return_value = presence_payload.user_away_presence
+async def test_set_presence(presence_service, mocked_presence_api_client, presence_payload):
+    mocked_presence_api_client.v2_user_presence_post.return_value = presence_payload.user_away_presence
 
     presence = await presence_service.set_presence(PresenceStatus.AWAY, True)
 
-    assert presence.category == 'AWAY'
+    assert presence.category == "AWAY"
     assert presence.userId == 14568529068038
 
 
 @pytest.mark.asyncio
-async def test_set_presence_failed(presence_service, presence_api_client):
-    presence_api_client.v2_user_presence_post.side_effect = ApiException(400)
+async def test_set_presence_failed(presence_service, mocked_presence_api_client):
+    mocked_presence_api_client.v2_user_presence_post.side_effect = ApiException(400)
 
     with pytest.raises(ApiException):
         await presence_service.set_presence(PresenceStatus.AWAY, True)
 
 
 @pytest.mark.asyncio
-async def test_create_presence_feed(presence_service, presence_api_client, presence_payload):
-    presence_api_client.v1_presence_feed_create_post.return_value = presence_payload.presence_feed_id
+async def test_create_presence_feed(presence_service, mocked_presence_api_client, presence_payload):
+    mocked_presence_api_client.v1_presence_feed_create_post.return_value = presence_payload.presence_feed_id
 
     feed_id = await presence_service.create_presence_feed()
 
-    assert feed_id == 'c4dca251-8639-48db-a9d4-f387089e17cf'
+    assert feed_id == "c4dca251-8639-48db-a9d4-f387089e17cf"
 
 
 @pytest.mark.asyncio
-async def test_create_presence_feed_failed(presence_service, presence_api_client):
-    presence_api_client.v1_presence_feed_create_post.side_effect = ApiException(400)
+async def test_create_presence_feed_failed(presence_service, mocked_presence_api_client):
+    mocked_presence_api_client.v1_presence_feed_create_post.side_effect = ApiException(400)
 
     with pytest.raises(ApiException):
         await presence_service.create_presence_feed()
 
 
 @pytest.mark.asyncio
-async def test_read_presence_feed(presence_service, presence_api_client, presence_payload):
-    presence_api_client.v1_presence_feed_feed_id_read_get.return_value = presence_payload.presence_feed
+async def test_read_presence_feed(presence_service, mocked_presence_api_client, presence_payload):
+    mocked_presence_api_client.v1_presence_feed_feed_id_read_get.return_value = presence_payload.presence_feed
 
-    presence_list = await presence_service.read_presence_feed('c4dca251-8639-48db-a9d4-f387089e17cf')
+    presence_list = await presence_service.read_presence_feed("c4dca251-8639-48db-a9d4-f387089e17cf")
 
     assert len(presence_list) == 2
-    assert presence_list[0].category == 'AVAILABLE'
+    assert presence_list[0].category == "AVAILABLE"
     assert presence_list[0].userId == 7078106103901
-    assert presence_list[1].category == 'ON_THE_PHONE'
+    assert presence_list[1].category == "ON_THE_PHONE"
     assert presence_list[1].userId == 7078106103902
 
 
 @pytest.mark.asyncio
-async def test_read_presence_feed_failed(presence_service, presence_api_client):
-    presence_api_client.v1_presence_feed_feed_id_read_get.side_effect = ApiException(400)
+async def test_read_presence_feed_failed(presence_service, mocked_presence_api_client):
+    mocked_presence_api_client.v1_presence_feed_feed_id_read_get.side_effect = ApiException(400)
 
     with pytest.raises(ApiException):
-        await presence_service.read_presence_feed('1234')
+        await presence_service.read_presence_feed("1234")
 
 
 @pytest.mark.asyncio
-async def test_delete_presence_feed(presence_service, presence_api_client, presence_payload):
-    presence_api_client.v1_presence_feed_feed_id_delete_post.return_value = presence_payload.presence_feed_id
+async def test_delete_presence_feed(presence_service, mocked_presence_api_client, presence_payload):
+    mocked_presence_api_client.v1_presence_feed_feed_id_delete_post.return_value = presence_payload.presence_feed_id
 
-    feed_id = await presence_service.delete_presence_feed('c4dca251-8639-48db-a9d4-f387089e17cf')
+    feed_id = await presence_service.delete_presence_feed("c4dca251-8639-48db-a9d4-f387089e17cf")
 
-    assert feed_id == 'c4dca251-8639-48db-a9d4-f387089e17cf'
+    assert feed_id == "c4dca251-8639-48db-a9d4-f387089e17cf"
 
 
 @pytest.mark.asyncio
-async def test_delete_presence_feed_failed(presence_service, presence_api_client):
-    presence_api_client.v1_presence_feed_feed_id_delete_post.side_effect = ApiException(400)
+async def test_delete_presence_feed_failed(presence_service, mocked_presence_api_client):
+    mocked_presence_api_client.v1_presence_feed_feed_id_delete_post.side_effect = ApiException(400)
 
     with pytest.raises(ApiException):
-        await presence_service.delete_presence_feed('1234')
+        await presence_service.delete_presence_feed("1234")
 
 
 @pytest.mark.asyncio
-async def test_set_user_presence(presence_service, presence_api_client, presence_payload):
-    presence_api_client.v3_user_presence_post.return_value = presence_payload.user_presence
+async def test_set_user_presence(presence_service, mocked_presence_api_client, presence_payload):
+    mocked_presence_api_client.v3_user_presence_post.return_value = presence_payload.user_presence
 
     presence = await presence_service.set_user_presence(14568529068038, PresenceStatus.AVAILABLE, True)
 
     assert presence.userId == 14568529068038
-    assert presence.category == 'AVAILABLE'
+    assert presence.category == "AVAILABLE"

--- a/tests/core/service/presence/presence_service_test.py
+++ b/tests/core/service/presence/presence_service_test.py
@@ -1,24 +1,23 @@
 from unittest.mock import MagicMock, AsyncMock
 import pytest
 from symphony.bdk.gen import ApiException
-from tests.utils.resource_utils import object_from_json_relative_path
-
+from symphony.bdk.gen.pod_api.presence_api import PresenceApi
 from symphony.bdk.core.auth.auth_session import AuthSession
 from symphony.bdk.core.service.presence.presence_service import PresenceService, PresenceStatus
 
-from symphony.bdk.gen.pod_api.presence_api import PresenceApi
+from tests.utils.resource_utils import object_from_json_relative_path
 
 
-@pytest.fixture()
-def auth_session():
+@pytest.fixture(name='auth_session')
+def fixture_auth_session():
     bot_session = AuthSession(None)
     bot_session.session_token = 'session_token'
     bot_session.key_manager_token = 'km_token'
     return bot_session
 
 
-@pytest.fixture()
-def mocked_presence_api_client():
+@pytest.fixture(name='presence_api_client')
+def fixture_presence_api_client():
     api_client = MagicMock(PresenceApi)
     api_client.v2_user_presence_get = AsyncMock()
     api_client.v2_users_presence_get = AsyncMock()
@@ -32,168 +31,168 @@ def mocked_presence_api_client():
     return api_client
 
 
-@pytest.fixture()
-def presence_service(mocked_presence_api_client, auth_session):
-    return PresenceService(mocked_presence_api_client, auth_session)
+@pytest.fixture(name='presence_service')
+def fixture_presence_service(presence_api_client, auth_session):
+    return PresenceService(presence_api_client, auth_session)
 
 
-@pytest.fixture()
-def presence_payload():
-    return object_from_json_relative_path("presence_response/presence_payload.json")
+@pytest.fixture(name='presence_payload')
+def fixture_presence_payload():
+    return object_from_json_relative_path('presence_response/presence_payload.json')
 
 
 @pytest.mark.asyncio
-async def test_get_presence(presence_service, mocked_presence_api_client, presence_payload):
-    mocked_presence_api_client.v2_user_presence_get.return_value = presence_payload.user_presence
+async def test_get_presence(presence_service, presence_api_client, presence_payload):
+    presence_api_client.v2_user_presence_get.return_value = presence_payload.user_presence
 
     presence = await presence_service.get_presence()
 
-    assert presence.category == "AVAILABLE"
+    assert presence.category == 'AVAILABLE'
     assert presence.userId == 14568529068038
 
 
 @pytest.mark.asyncio
-async def test_get_presence_failed(presence_service, mocked_presence_api_client):
-    mocked_presence_api_client.v2_user_presence_get.side_effect = ApiException(400)
+async def test_get_presence_failed(presence_service, presence_api_client):
+    presence_api_client.v2_user_presence_get.side_effect = ApiException(400)
 
     with pytest.raises(ApiException):
         await presence_service.get_presence()
 
 
 @pytest.mark.asyncio
-async def test_get_all_presence(presence_service, mocked_presence_api_client, presence_payload):
-    mocked_presence_api_client.v2_users_presence_get.return_value = presence_payload.multiple_presences
+async def test_get_all_presence(presence_service, presence_api_client, presence_payload):
+    presence_api_client.v2_users_presence_get.return_value = presence_payload.multiple_presences
 
     presence_list = await presence_service.get_all_presence(1234, 5000)
 
     assert len(presence_list) == 2
     assert presence_list[0].userId == 14568529068038
-    assert presence_list[0].category == "AVAILABLE"
+    assert presence_list[0].category == 'AVAILABLE'
     assert presence_list[0].timestamp == 1533928483800
     assert presence_list[1].userId == 974217539631
-    assert presence_list[1].category == "OFFLINE"
+    assert presence_list[1].category == 'OFFLINE'
 
 
 @pytest.mark.asyncio
-async def test_get_all_presence_failed(presence_service, mocked_presence_api_client):
-    mocked_presence_api_client.v2_users_presence_get.side_effect = ApiException(400)
+async def test_get_all_presence_failed(presence_service, presence_api_client):
+    presence_api_client.v2_users_presence_get.side_effect = ApiException(400)
 
     with pytest.raises(ApiException):
         await presence_service.get_all_presence(1234, 5000)
 
 
 @pytest.mark.asyncio
-async def test_get_user_presence(presence_service, mocked_presence_api_client, presence_payload):
-    mocked_presence_api_client.v3_user_uid_presence_get.return_value = presence_payload.user_presence
+async def test_get_user_presence(presence_service, presence_api_client, presence_payload):
+    presence_api_client.v3_user_uid_presence_get.return_value = presence_payload.user_presence
 
     presence = await presence_service.get_user_presence(1234, True)
 
     assert presence.userId == 14568529068038
-    assert presence.category == "AVAILABLE"
+    assert presence.category == 'AVAILABLE'
 
 
 @pytest.mark.asyncio
-async def test_get_user_presence_failed(presence_service, mocked_presence_api_client):
-    mocked_presence_api_client.v3_user_uid_presence_get.side_effect = ApiException(400)
+async def test_get_user_presence_failed(presence_service, presence_api_client):
+    presence_api_client.v3_user_uid_presence_get.side_effect = ApiException(400)
 
     with pytest.raises(ApiException):
         await presence_service.get_user_presence(1234, True)
 
 
 @pytest.mark.asyncio
-async def test_external_presence_interest(presence_service, mocked_presence_api_client):
+async def test_external_presence_interest(presence_service, presence_api_client):
     uid_list = [1234]
     await presence_service.external_presence_interest(uid_list)
-    mocked_presence_api_client.v1_user_presence_register_post.assert_called_once_with(session_token="session_token",
+    presence_api_client.v1_user_presence_register_post.assert_called_once_with(session_token='session_token',
                                                                                       uid_list=uid_list)
 
 
 @pytest.mark.asyncio
-async def test_external_presence_interest_failed(presence_service, mocked_presence_api_client):
-    mocked_presence_api_client.v1_user_presence_register_post.side_effect = ApiException(400)
+async def test_external_presence_interest_failed(presence_service, presence_api_client):
+    presence_api_client.v1_user_presence_register_post.side_effect = ApiException(400)
     uid_list = [1234]
     with pytest.raises(ApiException):
         await presence_service.external_presence_interest(uid_list)
 
 
 @pytest.mark.asyncio
-async def test_set_presence(presence_service, mocked_presence_api_client, presence_payload):
-    mocked_presence_api_client.v2_user_presence_post.return_value = presence_payload.user_away_presence
+async def test_set_presence(presence_service, presence_api_client, presence_payload):
+    presence_api_client.v2_user_presence_post.return_value = presence_payload.user_away_presence
 
     presence = await presence_service.set_presence(PresenceStatus.AWAY, True)
 
-    assert presence.category == "AWAY"
+    assert presence.category == 'AWAY'
     assert presence.userId == 14568529068038
 
 
 @pytest.mark.asyncio
-async def test_set_presence_failed(presence_service, mocked_presence_api_client):
-    mocked_presence_api_client.v2_user_presence_post.side_effect = ApiException(400)
+async def test_set_presence_failed(presence_service, presence_api_client):
+    presence_api_client.v2_user_presence_post.side_effect = ApiException(400)
 
     with pytest.raises(ApiException):
         await presence_service.set_presence(PresenceStatus.AWAY, True)
 
 
 @pytest.mark.asyncio
-async def test_create_presence_feed(presence_service, mocked_presence_api_client, presence_payload):
-    mocked_presence_api_client.v1_presence_feed_create_post.return_value = presence_payload.presence_feed_id
+async def test_create_presence_feed(presence_service, presence_api_client, presence_payload):
+    presence_api_client.v1_presence_feed_create_post.return_value = presence_payload.presence_feed_id
 
     feed_id = await presence_service.create_presence_feed()
 
-    assert feed_id == "c4dca251-8639-48db-a9d4-f387089e17cf"
+    assert feed_id == 'c4dca251-8639-48db-a9d4-f387089e17cf'
 
 
 @pytest.mark.asyncio
-async def test_create_presence_feed_failed(presence_service, mocked_presence_api_client):
-    mocked_presence_api_client.v1_presence_feed_create_post.side_effect = ApiException(400)
+async def test_create_presence_feed_failed(presence_service, presence_api_client):
+    presence_api_client.v1_presence_feed_create_post.side_effect = ApiException(400)
 
     with pytest.raises(ApiException):
         await presence_service.create_presence_feed()
 
 
 @pytest.mark.asyncio
-async def test_read_presence_feed(presence_service, mocked_presence_api_client, presence_payload):
-    mocked_presence_api_client.v1_presence_feed_feed_id_read_get.return_value = presence_payload.presence_feed
+async def test_read_presence_feed(presence_service, presence_api_client, presence_payload):
+    presence_api_client.v1_presence_feed_feed_id_read_get.return_value = presence_payload.presence_feed
 
-    presence_list = await presence_service.read_presence_feed("c4dca251-8639-48db-a9d4-f387089e17cf")
+    presence_list = await presence_service.read_presence_feed('c4dca251-8639-48db-a9d4-f387089e17cf')
 
     assert len(presence_list) == 2
-    assert presence_list[0].category == "AVAILABLE"
+    assert presence_list[0].category == 'AVAILABLE'
     assert presence_list[0].userId == 7078106103901
-    assert presence_list[1].category == "ON_THE_PHONE"
+    assert presence_list[1].category == 'ON_THE_PHONE'
     assert presence_list[1].userId == 7078106103902
 
 
 @pytest.mark.asyncio
-async def test_read_presence_feed_failed(presence_service, mocked_presence_api_client):
-    mocked_presence_api_client.v1_presence_feed_feed_id_read_get.side_effect = ApiException(400)
+async def test_read_presence_feed_failed(presence_service, presence_api_client):
+    presence_api_client.v1_presence_feed_feed_id_read_get.side_effect = ApiException(400)
 
     with pytest.raises(ApiException):
-        await presence_service.read_presence_feed("1234")
+        await presence_service.read_presence_feed('1234')
 
 
 @pytest.mark.asyncio
-async def test_delete_presence_feed(presence_service, mocked_presence_api_client, presence_payload):
-    mocked_presence_api_client.v1_presence_feed_feed_id_delete_post.return_value = presence_payload.presence_feed_id
+async def test_delete_presence_feed(presence_service, presence_api_client, presence_payload):
+    presence_api_client.v1_presence_feed_feed_id_delete_post.return_value = presence_payload.presence_feed_id
 
-    feed_id = await presence_service.delete_presence_feed("c4dca251-8639-48db-a9d4-f387089e17cf")
+    feed_id = await presence_service.delete_presence_feed('c4dca251-8639-48db-a9d4-f387089e17cf')
 
-    assert feed_id == "c4dca251-8639-48db-a9d4-f387089e17cf"
+    assert feed_id == 'c4dca251-8639-48db-a9d4-f387089e17cf'
 
 
 @pytest.mark.asyncio
-async def test_delete_presence_feed_failed(presence_service, mocked_presence_api_client):
-    mocked_presence_api_client.v1_presence_feed_feed_id_delete_post.side_effect = ApiException(400)
+async def test_delete_presence_feed_failed(presence_service, presence_api_client):
+    presence_api_client.v1_presence_feed_feed_id_delete_post.side_effect = ApiException(400)
 
     with pytest.raises(ApiException):
-        await presence_service.delete_presence_feed("1234")
+        await presence_service.delete_presence_feed('1234')
 
 
 @pytest.mark.asyncio
-async def test_set_user_presence(presence_service, mocked_presence_api_client, presence_payload):
-    mocked_presence_api_client.v3_user_presence_post.return_value = presence_payload.user_presence
+async def test_set_user_presence(presence_service, presence_api_client, presence_payload):
+    presence_api_client.v3_user_presence_post.return_value = presence_payload.user_presence
 
     presence = await presence_service.set_user_presence(14568529068038, PresenceStatus.AVAILABLE, True)
 
     assert presence.userId == 14568529068038
-    assert presence.category == "AVAILABLE"
+    assert presence.category == 'AVAILABLE'

--- a/tests/core/service/signal/signal_service_test.py
+++ b/tests/core/service/signal/signal_service_test.py
@@ -11,20 +11,20 @@ from tests.utils.resource_utils import object_from_json_relative_path, object_fr
     get_deserialized_object_from_json
 
 
-@pytest.fixture(name='auth_session')
+@pytest.fixture(name="auth_session")
 def fixture_auth_session():
     bot_session = AuthSession(None)
-    bot_session.session_token = 'session_token'
-    bot_session.key_manager_token = 'km_token'
+    bot_session.session_token = "session_token"
+    bot_session.key_manager_token = "km_token"
     return bot_session
 
 
-@pytest.fixture(name='signals_api')
+@pytest.fixture(name="signals_api")
 def fixture_signals_api():
     return MagicMock(SignalsApi)
 
 
-@pytest.fixture(name='signal_service')
+@pytest.fixture(name="signal_service")
 def fixture_signal_service(signals_api, auth_session):
     service = SignalService(signals_api, auth_session)
     return service
@@ -33,7 +33,7 @@ def fixture_signal_service(signals_api, auth_session):
 @pytest.mark.asyncio
 async def test_list_signals(signals_api, signal_service):
     signals_api.v1_signals_list_get = AsyncMock()
-    signals_api.v1_signals_list_get.return_value = get_deserialized_object_from_json('signal/list_signals.json',
+    signals_api.v1_signals_list_get.return_value = get_deserialized_object_from_json("signal/list_signals.json",
                                                                                      SignalList)
 
     signals = await signal_service.list_signals()
@@ -42,18 +42,18 @@ async def test_list_signals(signals_api, signal_service):
     signals_api.v1_signals_list_get.assert_called_with(
         skip=0,
         limit=50,
-        session_token='session_token',
-        key_manager_token='km_token'
+        session_token="session_token",
+        key_manager_token="km_token"
     )
 
     assert len(signal_list) == 2
-    assert signal_list[0].id == 'signal_id1'
+    assert signal_list[0].id == "signal_id1"
 
 
 @pytest.mark.asyncio
 async def test_list_all_signals(signals_api, signal_service):
     signals_api.v1_signals_list_get = AsyncMock()
-    signals_api.v1_signals_list_get.return_value = get_deserialized_object_from_json('signal/list_signals.json',
+    signals_api.v1_signals_list_get.return_value = get_deserialized_object_from_json("signal/list_signals.json",
                                                                                      SignalList)
 
     signal_list_gen = await signal_service.list_all_signals()
@@ -62,87 +62,87 @@ async def test_list_all_signals(signals_api, signal_service):
     signals_api.v1_signals_list_get.assert_called_with(
         skip=0,
         limit=50,
-        session_token='session_token',
-        key_manager_token='km_token'
+        session_token="session_token",
+        key_manager_token="km_token"
     )
 
     assert len(signal_list) == 2
-    assert signal_list[0].id == 'signal_id1'
+    assert signal_list[0].id == "signal_id1"
 
 
 @pytest.mark.asyncio
 async def test_list_signals_with_skip_and_limit(signals_api, signal_service):
     signals_api.v1_signals_list_get = AsyncMock()
     signals_api.v1_signals_list_get.return_value = \
-        object_from_json_relative_path('signal/list_signals.json')
+        object_from_json_relative_path("signal/list_signals.json")
 
     signal_list = await signal_service.list_signals(3, 30)
 
     signals_api.v1_signals_list_get.assert_called_with(
         skip=3,
         limit=30,
-        session_token='session_token',
-        key_manager_token='km_token'
+        session_token="session_token",
+        key_manager_token="km_token"
     )
 
     assert len(signal_list) == 2
-    assert signal_list[0].id == 'signal_id1'
+    assert signal_list[0].id == "signal_id1"
 
 
 @pytest.mark.asyncio
 async def test_get_signal(signals_api, signal_service):
     signals_api.v1_signals_id_get_get = AsyncMock()
     signals_api.v1_signals_id_get_get.return_value = \
-        object_from_json_relative_path('signal/create_signal.json')
+        object_from_json_relative_path("signal/create_signal.json")
 
-    signal = await signal_service.get_signal('signal_id')
+    signal = await signal_service.get_signal("signal_id")
 
     signals_api.v1_signals_id_get_get.assert_called_with(
-        id='signal_id',
-        session_token='session_token',
-        key_manager_token='km_token'
+        id="signal_id",
+        session_token="session_token",
+        key_manager_token="km_token"
     )
 
-    assert signal.id == 'signal_id'
-    assert signal.name == 'hash and cash'
-    assert signal.query == 'HASHTAG:hash AND CASHTAG:cash'
+    assert signal.id == "signal_id"
+    assert signal.name == "hash and cash"
+    assert signal.query == "HASHTAG:hash AND CASHTAG:cash"
 
 
 @pytest.mark.asyncio
 async def test_create_signal(signals_api, signal_service):
     signals_api.v1_signals_create_post = AsyncMock()
     signals_api.v1_signals_create_post.return_value = \
-        object_from_json_relative_path('signal/create_signal.json')
+        object_from_json_relative_path("signal/create_signal.json")
 
     signal = await signal_service.create_signal(BaseSignal())
 
     signals_api.v1_signals_create_post.assert_called_with(
         signal=BaseSignal(),
-        session_token='session_token',
-        key_manager_token='km_token'
+        session_token="session_token",
+        key_manager_token="km_token"
     )
-    assert signal.id == 'signal_id'
-    assert signal.name == 'hash and cash'
-    assert signal.query == 'HASHTAG:hash AND CASHTAG:cash'
+    assert signal.id == "signal_id"
+    assert signal.name == "hash and cash"
+    assert signal.query == "HASHTAG:hash AND CASHTAG:cash"
 
 
 @pytest.mark.asyncio
 async def test_update_signal(signals_api, signal_service):
     signals_api.v1_signals_id_update_post = AsyncMock()
     signals_api.v1_signals_id_update_post.return_value = \
-        object_from_json_relative_path('signal/update_signal.json')
+        object_from_json_relative_path("signal/update_signal.json")
 
-    signal = await signal_service.update_signal('signal_id', BaseSignal())
+    signal = await signal_service.update_signal("signal_id", BaseSignal())
 
     signals_api.v1_signals_id_update_post.assert_called_with(
-        id='signal_id',
+        id="signal_id",
         signal=BaseSignal(),
-        session_token='session_token',
-        key_manager_token='km_token'
+        session_token="session_token",
+        key_manager_token="km_token"
     )
 
-    assert signal.id == 'signal_id'
-    assert signal.name == 'hash and cash updated'
+    assert signal.id == "signal_id"
+    assert signal.name == "hash and cash updated"
 
 
 @pytest.mark.asyncio
@@ -151,33 +151,33 @@ async def test_delete_signal(signals_api, signal_service):
     signals_api.v1_signals_id_delete_post = AsyncMock()
     signals_api.v1_signals_id_delete_post.return_value = object_from_json(return_value)
 
-    response = await signal_service.delete_signal('signal_id')
+    response = await signal_service.delete_signal("signal_id")
 
     signals_api.v1_signals_id_delete_post.assert_called_with(
-        id='signal_id',
-        session_token='session_token',
-        key_manager_token='km_token'
+        id="signal_id",
+        session_token="session_token",
+        key_manager_token="km_token"
     )
 
-    assert response.message == 'Signal signal_id deleted'
+    assert response.message == "Signal signal_id deleted"
 
 
 @pytest.mark.asyncio
 async def test_subscribe_users_to_signal(signals_api, signal_service):
     signals_api.v1_signals_id_subscribe_post = AsyncMock()
     signals_api.v1_signals_id_subscribe_post.return_value = \
-        object_from_json_relative_path('signal/subscribe_signal.json')
+        object_from_json_relative_path("signal/subscribe_signal.json")
     user_ids = [123, 465, 789]
 
     channel_subscription_response = await signal_service.subscribe_users_to_signal(
-        'signal_id', True, user_ids)
+        "signal_id", True, user_ids)
 
     signals_api.v1_signals_id_subscribe_post.assert_called_with(
-        id='signal_id',
+        id="signal_id",
         pushed=True,
         users=user_ids,
-        session_token='session_token',
-        key_manager_token='km_token'
+        session_token="session_token",
+        key_manager_token="km_token"
     )
 
     assert channel_subscription_response.requestedSubscription == 3
@@ -188,17 +188,17 @@ async def test_subscribe_users_to_signal(signals_api, signal_service):
 async def test_unsubscribe_users_to_signal(signals_api, signal_service):
     signals_api.v1_signals_id_unsubscribe_post = AsyncMock()
     signals_api.v1_signals_id_unsubscribe_post.return_value = \
-        object_from_json_relative_path('signal/subscribe_signal.json')
+        object_from_json_relative_path("signal/subscribe_signal.json")
     user_ids = [123, 465, 789]
 
     channel_subscription_response = await signal_service.unsubscribe_users_to_signal(
-        'signal_id', user_ids)
+        "signal_id", user_ids)
 
     signals_api.v1_signals_id_unsubscribe_post.assert_called_with(
-        id='signal_id',
+        id="signal_id",
         users=user_ids,
-        session_token='session_token',
-        key_manager_token='km_token'
+        session_token="session_token",
+        key_manager_token="km_token"
     )
 
     assert channel_subscription_response.requestedSubscription == 3
@@ -209,16 +209,16 @@ async def test_unsubscribe_users_to_signal(signals_api, signal_service):
 async def test_list_subscribers(signals_api, signal_service):
     signals_api.v1_signals_id_subscribers_get = AsyncMock()
     signals_api.v1_signals_id_subscribers_get.return_value = \
-        object_from_json_relative_path('signal/list_subscribers.json')
+        object_from_json_relative_path("signal/list_subscribers.json")
 
-    channel_subscribers = await signal_service.list_subscribers('signal_id')
+    channel_subscribers = await signal_service.list_subscribers("signal_id")
 
     signals_api.v1_signals_id_subscribers_get.assert_called_with(
-        id='signal_id',
+        id="signal_id",
         skip=0,
         limit=50,
-        session_token='session_token',
-        key_manager_token='km_token'
+        session_token="session_token",
+        key_manager_token="km_token"
     )
 
     assert channel_subscribers.total == 150
@@ -229,16 +229,16 @@ async def test_list_subscribers(signals_api, signal_service):
 async def test_list_subscribers_with_skip_and_limit(signals_api, signal_service):
     signals_api.v1_signals_id_subscribers_get = AsyncMock()
     signals_api.v1_signals_id_subscribers_get.return_value = \
-        object_from_json_relative_path('signal/list_subscribers.json')
+        object_from_json_relative_path("signal/list_subscribers.json")
 
-    channel_subscribers = await signal_service.list_subscribers('signal_id', 1, 10)
+    channel_subscribers = await signal_service.list_subscribers("signal_id", 1, 10)
 
     signals_api.v1_signals_id_subscribers_get.assert_called_with(
-        id='signal_id',
+        id="signal_id",
         skip=1,
         limit=10,
-        session_token='session_token',
-        key_manager_token='km_token'
+        session_token="session_token",
+        key_manager_token="km_token"
     )
 
     assert channel_subscribers.total == 150
@@ -249,17 +249,17 @@ async def test_list_subscribers_with_skip_and_limit(signals_api, signal_service)
 async def test_list_all_subscribers(signals_api, signal_service):
     signals_api.v1_signals_id_subscribers_get = AsyncMock()
     signals_api.v1_signals_id_subscribers_get.return_value = \
-        object_from_json_relative_path('signal/list_subscribers.json')
+        object_from_json_relative_path("signal/list_subscribers.json")
 
-    channel_subscribers_gen = await signal_service.list_all_subscribers('signal_id', chunk_size=10)
+    channel_subscribers_gen = await signal_service.list_all_subscribers("signal_id", chunk_size=10)
     subscribers = [s async for s in channel_subscribers_gen]
 
     signals_api.v1_signals_id_subscribers_get.assert_called_with(
-        id='signal_id',
+        id="signal_id",
         skip=0,
         limit=10,
-        session_token='session_token',
-        key_manager_token='km_token'
+        session_token="session_token",
+        key_manager_token="km_token"
     )
 
     assert len(subscribers) == 3

--- a/tests/core/service/signal/signal_service_test.py
+++ b/tests/core/service/signal/signal_service_test.py
@@ -1,34 +1,31 @@
-from collections import namedtuple
 from unittest.mock import MagicMock, AsyncMock
 
 import pytest
 
 from symphony.bdk.core.auth.auth_session import AuthSession
 from symphony.bdk.core.service.signal.signal_service import SignalService
-from symphony.bdk.gen import ApiClient
 from symphony.bdk.gen.agent_api.signals_api import SignalsApi
 from symphony.bdk.gen.agent_model.base_signal import BaseSignal
 from symphony.bdk.gen.agent_model.signal_list import SignalList
-from symphony.bdk.gen.rest import RESTResponse
-from tests.utils.resource_utils import object_from_json_relative_path, object_from_json, get_resource_content, \
+from tests.utils.resource_utils import object_from_json_relative_path, object_from_json, \
     get_deserialized_object_from_json
 
 
-@pytest.fixture()
-def auth_session():
+@pytest.fixture(name='auth_session')
+def fixture_auth_session():
     bot_session = AuthSession(None)
     bot_session.session_token = 'session_token'
     bot_session.key_manager_token = 'km_token'
     return bot_session
 
 
-@pytest.fixture()
-def signals_api():
+@pytest.fixture(name='signals_api')
+def fixture_signals_api():
     return MagicMock(SignalsApi)
 
 
-@pytest.fixture()
-def signal_service(signals_api, auth_session):
+@pytest.fixture(name='signal_service')
+def fixture_signal_service(signals_api, auth_session):
     service = SignalService(signals_api, auth_session)
     return service
 

--- a/tests/core/service/stream/stream_service_test.py
+++ b/tests/core/service/stream/stream_service_test.py
@@ -20,11 +20,11 @@ from symphony.bdk.gen.pod_model.v2_room_search_criteria import V2RoomSearchCrite
 from symphony.bdk.gen.pod_model.v3_room_attributes import V3RoomAttributes
 from tests.utils.resource_utils import object_from_json_relative_path, get_deserialized_object_from_json
 
-KM_TOKEN = 'km_token'
-SESSION_TOKEN = 'session_token'
+KM_TOKEN = "km_token"
+SESSION_TOKEN = "session_token"
 
 
-@pytest.fixture(name='auth_session')
+@pytest.fixture(name="auth_session")
 def fixture_auth_session():
     auth_session = AuthSession(None)
     auth_session.session_token = SESSION_TOKEN
@@ -32,7 +32,7 @@ def fixture_auth_session():
     return auth_session
 
 
-@pytest.fixture(name='mocked_api_client')
+@pytest.fixture(name="mocked_api_client")
 def fixture_mocked_api_client():
     api_client = MagicMock(ApiClient)
     api_client.call_api = AsyncMock()
@@ -40,42 +40,42 @@ def fixture_mocked_api_client():
     return api_client
 
 
-@pytest.fixture(name='streams_api')
+@pytest.fixture(name="streams_api")
 def fixture_streams_api(mocked_api_client):
     return Mock(wraps=StreamsApi(mocked_api_client))
 
 
-@pytest.fixture(name='room_membership_api')
+@pytest.fixture(name="room_membership_api")
 def fixture_room_membership_api(mocked_api_client):
     return Mock(wraps=RoomMembershipApi(mocked_api_client))
 
 
-@pytest.fixture(name='share_api')
+@pytest.fixture(name="share_api")
 def fixture_share_api(mocked_api_client):
     return Mock(wraps=ShareApi(mocked_api_client))
 
 
-@pytest.fixture(name='stream_service')
+@pytest.fixture(name="stream_service")
 def fixture_stream_service(streams_api, room_membership_api, share_api, auth_session):
     return StreamService(streams_api, room_membership_api, share_api, auth_session)
 
 
 @pytest.mark.asyncio
 async def test_get_stream(mocked_api_client, stream_service, streams_api):
-    mocked_api_client.call_api.return_value = object_from_json_relative_path('stream/get_stream.json')
+    mocked_api_client.call_api.return_value = object_from_json_relative_path("stream/get_stream.json")
 
-    stream_id = 'stream_id'
+    stream_id = "stream_id"
     stream_attributes = await stream_service.get_stream(stream_id)
 
     streams_api.v2_streams_sid_info_get.assert_called_once_with(sid=stream_id, session_token=SESSION_TOKEN)
-    assert stream_attributes.id == 'ubaSiuUsc_j-_lVQ8vhAz3___opSJdJZdA'
-    assert stream_attributes.roomAttributes.name == 'New room name'
-    assert stream_attributes.streamType.type == 'ROOM'
+    assert stream_attributes.id == "ubaSiuUsc_j-_lVQ8vhAz3___opSJdJZdA"
+    assert stream_attributes.roomAttributes.name == "New room name"
+    assert stream_attributes.streamType.type == "ROOM"
 
 
 @pytest.mark.asyncio
 async def test_list_streams(mocked_api_client, stream_service, streams_api):
-    mocked_api_client.call_api.return_value = get_deserialized_object_from_json('stream/list_streams.json', StreamList)
+    mocked_api_client.call_api.return_value = get_deserialized_object_from_json("stream/list_streams.json", StreamList)
 
     stream_filter = StreamFilter()
     skip = 1
@@ -86,15 +86,15 @@ async def test_list_streams(mocked_api_client, stream_service, streams_api):
     streams_api.v1_streams_list_post.assert_called_once_with(filter=stream_filter, skip=skip, limit=limit,
                                                              session_token=SESSION_TOKEN)
     assert len(streams.value) == 2
-    assert streams.value[0].id == 'ouAS1QXEHtIhXdZq4NzJBX___oscpQFcdA'
-    assert streams.value[0].room_attributes.name == 'Room APP-3033'
-    assert streams.value[1].id == 'z22OMRPxSdRFBfH_oojGkn___orihaxrdA'
-    assert streams.value[1].room_attributes.name == 'Test BDK'
+    assert streams.value[0].id == "ouAS1QXEHtIhXdZq4NzJBX___oscpQFcdA"
+    assert streams.value[0].room_attributes.name == "Room APP-3033"
+    assert streams.value[1].id == "z22OMRPxSdRFBfH_oojGkn___orihaxrdA"
+    assert streams.value[1].room_attributes.name == "Test BDK"
 
 
 @pytest.mark.asyncio
 async def test_list_all_streams(mocked_api_client, stream_service, streams_api):
-    mocked_api_client.call_api.return_value = get_deserialized_object_from_json('stream/list_streams.json', StreamList)
+    mocked_api_client.call_api.return_value = get_deserialized_object_from_json("stream/list_streams.json", StreamList)
 
     stream_filter = StreamFilter()
     limit = 4
@@ -105,18 +105,18 @@ async def test_list_all_streams(mocked_api_client, stream_service, streams_api):
     streams_api.v1_streams_list_post.assert_called_once_with(filter=stream_filter, skip=0, limit=limit,
                                                              session_token=SESSION_TOKEN)
     assert len(streams) == 2
-    assert streams[0].id == 'ouAS1QXEHtIhXdZq4NzJBX___oscpQFcdA'
-    assert streams[0].room_attributes.name == 'Room APP-3033'
-    assert streams[1].id == 'z22OMRPxSdRFBfH_oojGkn___orihaxrdA'
-    assert streams[1].room_attributes.name == 'Test BDK'
+    assert streams[0].id == "ouAS1QXEHtIhXdZq4NzJBX___oscpQFcdA"
+    assert streams[0].room_attributes.name == "Room APP-3033"
+    assert streams[1].id == "z22OMRPxSdRFBfH_oojGkn___orihaxrdA"
+    assert streams[1].room_attributes.name == "Test BDK"
 
 
 @pytest.mark.asyncio
 async def test_add_member_to_room(mocked_api_client, stream_service, room_membership_api):
-    mocked_api_client.call_api.return_value = object_from_json_relative_path('stream/add_member.json')
+    mocked_api_client.call_api.return_value = object_from_json_relative_path("stream/add_member.json")
 
     user_id = 1234456
-    room_id = 'room_id'
+    room_id = "room_id"
     await stream_service.add_member_to_room(user_id, room_id)  # check no exception raised
 
     room_membership_api.v1_room_id_membership_add_post.assert_called_once_with(
@@ -125,10 +125,10 @@ async def test_add_member_to_room(mocked_api_client, stream_service, room_member
 
 @pytest.mark.asyncio
 async def test_remove_member_from_room(mocked_api_client, stream_service, room_membership_api):
-    mocked_api_client.call_api.return_value = object_from_json_relative_path('stream/remove_member.json')
+    mocked_api_client.call_api.return_value = object_from_json_relative_path("stream/remove_member.json")
 
     user_id = 1234456
-    room_id = 'room_id'
+    room_id = "room_id"
     await stream_service.remove_member_from_room(user_id, room_id)  # check no exception raised
 
     room_membership_api.v1_room_id_membership_remove_post.assert_called_once_with(
@@ -137,24 +137,24 @@ async def test_remove_member_from_room(mocked_api_client, stream_service, room_m
 
 @pytest.mark.asyncio
 async def test_share(mocked_api_client, stream_service, share_api):
-    mocked_api_client.call_api.return_value = object_from_json_relative_path('stream/share_article.json')
+    mocked_api_client.call_api.return_value = object_from_json_relative_path("stream/share_article.json")
 
-    stream_id = 'stream_id'
+    stream_id = "stream_id"
     share_content = ShareContent()
     message = await stream_service.share(stream_id, share_content)
 
     share_api.v3_stream_sid_share_post.assert_called_once_with(
         sid=stream_id, share_content=share_content, session_token=SESSION_TOKEN, key_manager_token=KM_TOKEN)
-    assert message.id == 'uRcu9fjRALpKLHnPR1k6-3___oh4wwAObQ'
-    assert message.streamId == 'ubaSiuUsc_j-_lVQ8vhAz3___opSJdJZdA'
+    assert message.id == "uRcu9fjRALpKLHnPR1k6-3___oh4wwAObQ"
+    assert message.streamId == "ubaSiuUsc_j-_lVQ8vhAz3___opSJdJZdA"
 
 
 @pytest.mark.asyncio
 async def test_promote_user(mocked_api_client, stream_service, room_membership_api):
-    mocked_api_client.call_api.return_value = object_from_json_relative_path('stream/member_promoted.json')
+    mocked_api_client.call_api.return_value = object_from_json_relative_path("stream/member_promoted.json")
 
     user_id = 12345
-    room_id = 'room_id'
+    room_id = "room_id"
     await stream_service.promote_user_to_room_owner(user_id, room_id)  # check no exception raised
 
     room_membership_api.v1_room_id_membership_promote_owner_post.assert_called_once_with(
@@ -163,10 +163,10 @@ async def test_promote_user(mocked_api_client, stream_service, room_membership_a
 
 @pytest.mark.asyncio
 async def test_demote_owner(mocked_api_client, stream_service, room_membership_api):
-    mocked_api_client.call_api.return_value = object_from_json_relative_path('stream/member_demoted.json')
+    mocked_api_client.call_api.return_value = object_from_json_relative_path("stream/member_demoted.json")
 
     user_id = 12345
-    room_id = 'room_id'
+    room_id = "room_id"
     await stream_service.demote_owner_to_room_participant(user_id, room_id)  # check no exception raised
 
     room_membership_api.v1_room_id_membership_demote_owner_post.assert_called_once_with(
@@ -175,33 +175,33 @@ async def test_demote_owner(mocked_api_client, stream_service, room_membership_a
 
 @pytest.mark.asyncio
 async def test_create_im(mocked_api_client, stream_service, streams_api):
-    mocked_api_client.call_api.return_value = object_from_json_relative_path('stream/create_im_or_mim.json')
+    mocked_api_client.call_api.return_value = object_from_json_relative_path("stream/create_im_or_mim.json")
 
     user_ids = [12334]
     stream = await stream_service.create_im_or_mim(user_ids)
 
     streams_api.v1_im_create_post.assert_called_once_with(uid_list=UserIdList(value=user_ids),
                                                           session_token=SESSION_TOKEN)
-    assert stream.id == '-M8s5WG7K8lAP7cpIiuyTH___oh4zK8EdA'
+    assert stream.id == "-M8s5WG7K8lAP7cpIiuyTH___oh4zK8EdA"
 
 
 @pytest.mark.asyncio
 async def test_create_room(mocked_api_client, stream_service, streams_api):
-    mocked_api_client.call_api.return_value = object_from_json_relative_path('stream/create_room.json')
+    mocked_api_client.call_api.return_value = object_from_json_relative_path("stream/create_room.json")
 
     room_attributes = V3RoomAttributes()
     room_details = await stream_service.create_room(room_attributes)
 
     streams_api.v3_room_create_post.assert_called_once_with(payload=room_attributes, session_token=SESSION_TOKEN)
-    assert room_details.roomAttributes.name == 'New fancy room'
-    assert room_details.roomSystemInfo.id == '7X1cP_3wMD4mr6rcp7j26X___oh4uDkVdA'
+    assert room_details.roomAttributes.name == "New fancy room"
+    assert room_details.roomSystemInfo.id == "7X1cP_3wMD4mr6rcp7j26X___oh4uDkVdA"
 
 
 @pytest.mark.asyncio
 async def test_search_rooms(mocked_api_client, stream_service, streams_api):
-    mocked_api_client.call_api.return_value = object_from_json_relative_path('stream/search_rooms.json')
+    mocked_api_client.call_api.return_value = object_from_json_relative_path("stream/search_rooms.json")
 
-    search_criteria = V2RoomSearchCriteria(query='query')
+    search_criteria = V2RoomSearchCriteria(query="query")
     skip = 1
     limit = 2
     search_results = await stream_service.search_rooms(search_criteria, skip, limit)
@@ -210,14 +210,14 @@ async def test_search_rooms(mocked_api_client, stream_service, streams_api):
                                                             session_token=SESSION_TOKEN)
     assert search_results.count == 1
     assert len(search_results.rooms) == 1
-    assert search_results.rooms[0].roomAttributes.name == 'New room name'
+    assert search_results.rooms[0].roomAttributes.name == "New room name"
 
 
 @pytest.mark.asyncio
 async def test_search_all_rooms(mocked_api_client, stream_service, streams_api):
-    mocked_api_client.call_api.return_value = object_from_json_relative_path('stream/search_rooms.json')
+    mocked_api_client.call_api.return_value = object_from_json_relative_path("stream/search_rooms.json")
 
-    search_criteria = V2RoomSearchCriteria(query='query')
+    search_criteria = V2RoomSearchCriteria(query="query")
     chunk_size = 3
 
     gen = await stream_service.search_all_rooms(search_criteria, chunk_size=chunk_size)
@@ -226,26 +226,26 @@ async def test_search_all_rooms(mocked_api_client, stream_service, streams_api):
     streams_api.v3_room_search_post.assert_called_once_with(query=search_criteria, skip=0, limit=chunk_size,
                                                             session_token=SESSION_TOKEN)
     assert len(search_results) == 1
-    assert search_results[0].roomAttributes.name == 'New room name'
+    assert search_results[0].roomAttributes.name == "New room name"
 
 
 @pytest.mark.asyncio
 async def test_get_room_info(mocked_api_client, stream_service, streams_api):
-    mocked_api_client.call_api.return_value = object_from_json_relative_path('stream/get_room_info.json')
+    mocked_api_client.call_api.return_value = object_from_json_relative_path("stream/get_room_info.json")
 
-    room_id = 'room_id'
+    room_id = "room_id"
     room_detail = await stream_service.get_room_info(room_id)
 
     streams_api.v3_room_id_info_get.assert_called_once_with(id=room_id, session_token=SESSION_TOKEN)
-    assert room_detail.roomAttributes.name == 'New room name'
-    assert room_detail.roomSystemInfo.id == 'ubaSiuUsc_j-_lVQ8vhAz3___opSJdJZdA'
+    assert room_detail.roomAttributes.name == "New room name"
+    assert room_detail.roomSystemInfo.id == "ubaSiuUsc_j-_lVQ8vhAz3___opSJdJZdA"
 
 
 @pytest.mark.asyncio
 async def test_set_room_active(mocked_api_client, stream_service, streams_api):
-    mocked_api_client.call_api.return_value = object_from_json_relative_path('stream/deactivate_room.json')
+    mocked_api_client.call_api.return_value = object_from_json_relative_path("stream/deactivate_room.json")
 
-    room_id = 'room_id'
+    room_id = "room_id"
     active = False
     room_detail = await stream_service.set_room_active(room_id, active)
 
@@ -256,35 +256,35 @@ async def test_set_room_active(mocked_api_client, stream_service, streams_api):
 
 @pytest.mark.asyncio
 async def test_update_room(mocked_api_client, stream_service, streams_api):
-    mocked_api_client.call_api.return_value = object_from_json_relative_path('stream/update_room.json')
+    mocked_api_client.call_api.return_value = object_from_json_relative_path("stream/update_room.json")
 
-    room_id = 'room_id'
+    room_id = "room_id"
     room_attributes = V3RoomAttributes()
     room_details = await stream_service.update_room(room_id, room_attributes)
 
     streams_api.v3_room_id_update_post.assert_called_once_with(id=room_id, payload=room_attributes,
                                                                session_token=SESSION_TOKEN)
-    assert room_details.roomAttributes.name == 'Test bot room'
-    assert room_details.roomSystemInfo.id == 'ubaSiuUsc_j-_lVQ8vhAz3___opSJdJZdA'
+    assert room_details.roomAttributes.name == "Test bot room"
+    assert room_details.roomSystemInfo.id == "ubaSiuUsc_j-_lVQ8vhAz3___opSJdJZdA"
 
 
 @pytest.mark.asyncio
 async def test_create_im_admin(mocked_api_client, stream_service, streams_api):
-    mocked_api_client.call_api.return_value = object_from_json_relative_path('stream/create_im_or_mim.json')
+    mocked_api_client.call_api.return_value = object_from_json_relative_path("stream/create_im_or_mim.json")
 
     user_ids = [12334]
     stream = await stream_service.create_im_admin(user_ids)
 
     streams_api.v1_admin_im_create_post.assert_called_once_with(uid_list=UserIdList(value=user_ids),
                                                                 session_token=SESSION_TOKEN)
-    assert stream.id == '-M8s5WG7K8lAP7cpIiuyTH___oh4zK8EdA'
+    assert stream.id == "-M8s5WG7K8lAP7cpIiuyTH___oh4zK8EdA"
 
 
 @pytest.mark.asyncio
 async def test_set_room_active_admin(mocked_api_client, stream_service, streams_api):
-    mocked_api_client.call_api.return_value = object_from_json_relative_path('stream/deactivate_room.json')
+    mocked_api_client.call_api.return_value = object_from_json_relative_path("stream/deactivate_room.json")
 
-    room_id = 'room_id'
+    room_id = "room_id"
     active = False
     room_detail = await stream_service.set_room_active_admin(room_id, active)
 
@@ -295,7 +295,7 @@ async def test_set_room_active_admin(mocked_api_client, stream_service, streams_
 
 @pytest.mark.asyncio
 async def test_list_streams_admin(mocked_api_client, stream_service, streams_api):
-    mocked_api_client.call_api.return_value = get_deserialized_object_from_json('stream/list_streams_admin.json',
+    mocked_api_client.call_api.return_value = get_deserialized_object_from_json("stream/list_streams_admin.json",
                                                                                 V2AdminStreamList)
 
     stream_filter = V2AdminStreamFilter()
@@ -307,13 +307,13 @@ async def test_list_streams_admin(mocked_api_client, stream_service, streams_api
                                                                    session_token=SESSION_TOKEN)
     assert streams.limit == 2
     assert len(streams.streams.value) == 2
-    assert streams.streams.value[0].id == 'hpRd80zAUnLv3NMhLVF3Ln___o3ULKRDdA'
-    assert streams.streams.value[1].id == '6hEzTqQjVPLLE9KgXLvsKn___o3TtL3ddA'
+    assert streams.streams.value[0].id == "hpRd80zAUnLv3NMhLVF3Ln___o3ULKRDdA"
+    assert streams.streams.value[1].id == "6hEzTqQjVPLLE9KgXLvsKn___o3TtL3ddA"
 
 
 @pytest.mark.asyncio
 async def test_list_all_streams_admin(mocked_api_client, stream_service, streams_api):
-    mocked_api_client.call_api.return_value = get_deserialized_object_from_json('stream/list_streams_admin.json',
+    mocked_api_client.call_api.return_value = get_deserialized_object_from_json("stream/list_streams_admin.json",
                                                                                 V2AdminStreamList)
 
     stream_filter = V2AdminStreamFilter()
@@ -325,16 +325,16 @@ async def test_list_all_streams_admin(mocked_api_client, stream_service, streams
     streams_api.v2_admin_streams_list_post.assert_called_once_with(filter=stream_filter, skip=0, limit=limit,
                                                                    session_token=SESSION_TOKEN)
     assert len(streams) == 2
-    assert streams[0].id == 'hpRd80zAUnLv3NMhLVF3Ln___o3ULKRDdA'
-    assert streams[1].id == '6hEzTqQjVPLLE9KgXLvsKn___o3TtL3ddA'
+    assert streams[0].id == "hpRd80zAUnLv3NMhLVF3Ln___o3ULKRDdA"
+    assert streams[1].id == "6hEzTqQjVPLLE9KgXLvsKn___o3TtL3ddA"
 
 
 @pytest.mark.asyncio
 async def test_list_stream_members(mocked_api_client, stream_service, streams_api):
-    mocked_api_client.call_api.return_value = get_deserialized_object_from_json('stream/list_stream_members.json',
+    mocked_api_client.call_api.return_value = get_deserialized_object_from_json("stream/list_stream_members.json",
                                                                                 V2MembershipList)
 
-    stream_id = 'stream_id'
+    stream_id = "stream_id"
     skip = 1
     limit = 2
     members = await stream_service.list_stream_members(stream_id, skip, limit)
@@ -349,10 +349,10 @@ async def test_list_stream_members(mocked_api_client, stream_service, streams_ap
 
 @pytest.mark.asyncio
 async def test_list_all_stream_members(mocked_api_client, stream_service, streams_api):
-    mocked_api_client.call_api.return_value = get_deserialized_object_from_json('stream/list_stream_members.json',
+    mocked_api_client.call_api.return_value = get_deserialized_object_from_json("stream/list_stream_members.json",
                                                                                 V2MembershipList)
 
-    stream_id = 'stream_id'
+    stream_id = "stream_id"
     limit = 5
     gen = await stream_service.list_all_stream_members(stream_id, limit)
     members = [m async for m in gen]
@@ -366,9 +366,9 @@ async def test_list_all_stream_members(mocked_api_client, stream_service, stream
 
 @pytest.mark.asyncio
 async def test_list_room_members(mocked_api_client, stream_service, room_membership_api):
-    mocked_api_client.call_api.return_value = object_from_json_relative_path('stream/list_room_members.json')
+    mocked_api_client.call_api.return_value = object_from_json_relative_path("stream/list_room_members.json")
 
-    room_id = 'room_id'
+    room_id = "room_id"
     members = await stream_service.list_room_members(room_id)
 
     room_membership_api.v2_room_id_membership_list_get.assert_called_once_with(id=room_id, session_token=SESSION_TOKEN)

--- a/tests/core/service/stream/stream_service_test.py
+++ b/tests/core/service/stream/stream_service_test.py
@@ -20,62 +20,62 @@ from symphony.bdk.gen.pod_model.v2_room_search_criteria import V2RoomSearchCrite
 from symphony.bdk.gen.pod_model.v3_room_attributes import V3RoomAttributes
 from tests.utils.resource_utils import object_from_json_relative_path, get_deserialized_object_from_json
 
-KM_TOKEN = "km_token"
-SESSION_TOKEN = "session_token"
+KM_TOKEN = 'km_token'
+SESSION_TOKEN = 'session_token'
 
 
-@pytest.fixture()
-def auth_session():
+@pytest.fixture(name='auth_session')
+def fixture_auth_session():
     auth_session = AuthSession(None)
     auth_session.session_token = SESSION_TOKEN
     auth_session.key_manager_token = KM_TOKEN
     return auth_session
 
 
-@pytest.fixture()
-def mocked_api_client():
+@pytest.fixture(name='mocked_api_client')
+def fixture_mocked_api_client():
     api_client = MagicMock(ApiClient)
     api_client.call_api = AsyncMock()
     api_client.configuration = Configuration()
     return api_client
 
 
-@pytest.fixture()
-def streams_api(mocked_api_client):
+@pytest.fixture(name='streams_api')
+def fixture_streams_api(mocked_api_client):
     return Mock(wraps=StreamsApi(mocked_api_client))
 
 
-@pytest.fixture()
-def room_membership_api(mocked_api_client):
+@pytest.fixture(name='room_membership_api')
+def fixture_room_membership_api(mocked_api_client):
     return Mock(wraps=RoomMembershipApi(mocked_api_client))
 
 
-@pytest.fixture()
-def share_api(mocked_api_client):
+@pytest.fixture(name='share_api')
+def fixture_share_api(mocked_api_client):
     return Mock(wraps=ShareApi(mocked_api_client))
 
 
-@pytest.fixture()
-def stream_service(streams_api, room_membership_api, share_api, auth_session):
+@pytest.fixture(name='stream_service')
+def fixture_stream_service(streams_api, room_membership_api, share_api, auth_session):
     return StreamService(streams_api, room_membership_api, share_api, auth_session)
 
 
 @pytest.mark.asyncio
 async def test_get_stream(mocked_api_client, stream_service, streams_api):
-    mocked_api_client.call_api.return_value = object_from_json_relative_path("stream/get_stream.json")
+    mocked_api_client.call_api.return_value = object_from_json_relative_path('stream/get_stream.json')
 
-    stream_id = "stream_id"
+    stream_id = 'stream_id'
     stream_attributes = await stream_service.get_stream(stream_id)
 
     streams_api.v2_streams_sid_info_get.assert_called_once_with(sid=stream_id, session_token=SESSION_TOKEN)
-    assert stream_attributes.id == "ubaSiuUsc_j-_lVQ8vhAz3___opSJdJZdA"
-    assert stream_attributes.streamType.type == "ROOM"
-    assert stream_attributes.roomAttributes.name == "New room name"
+    assert stream_attributes.id == 'ubaSiuUsc_j-_lVQ8vhAz3___opSJdJZdA'
+    assert stream_attributes.roomAttributes.name == 'New room name'
+    assert stream_attributes.streamType.type == 'ROOM'
 
 
 @pytest.mark.asyncio
 async def test_list_streams(mocked_api_client, stream_service, streams_api):
-    mocked_api_client.call_api.return_value = get_deserialized_object_from_json("stream/list_streams.json", StreamList)
+    mocked_api_client.call_api.return_value = get_deserialized_object_from_json('stream/list_streams.json', StreamList)
 
     stream_filter = StreamFilter()
     skip = 1
@@ -86,15 +86,15 @@ async def test_list_streams(mocked_api_client, stream_service, streams_api):
     streams_api.v1_streams_list_post.assert_called_once_with(filter=stream_filter, skip=skip, limit=limit,
                                                              session_token=SESSION_TOKEN)
     assert len(streams.value) == 2
-    assert streams.value[0].id == "ouAS1QXEHtIhXdZq4NzJBX___oscpQFcdA"
-    assert streams.value[0].room_attributes.name == "Room APP-3033"
-    assert streams.value[1].id == "z22OMRPxSdRFBfH_oojGkn___orihaxrdA"
-    assert streams.value[1].room_attributes.name == "Test BDK"
+    assert streams.value[0].id == 'ouAS1QXEHtIhXdZq4NzJBX___oscpQFcdA'
+    assert streams.value[0].room_attributes.name == 'Room APP-3033'
+    assert streams.value[1].id == 'z22OMRPxSdRFBfH_oojGkn___orihaxrdA'
+    assert streams.value[1].room_attributes.name == 'Test BDK'
 
 
 @pytest.mark.asyncio
 async def test_list_all_streams(mocked_api_client, stream_service, streams_api):
-    mocked_api_client.call_api.return_value = get_deserialized_object_from_json("stream/list_streams.json", StreamList)
+    mocked_api_client.call_api.return_value = get_deserialized_object_from_json('stream/list_streams.json', StreamList)
 
     stream_filter = StreamFilter()
     limit = 4
@@ -105,18 +105,18 @@ async def test_list_all_streams(mocked_api_client, stream_service, streams_api):
     streams_api.v1_streams_list_post.assert_called_once_with(filter=stream_filter, skip=0, limit=limit,
                                                              session_token=SESSION_TOKEN)
     assert len(streams) == 2
-    assert streams[0].id == "ouAS1QXEHtIhXdZq4NzJBX___oscpQFcdA"
-    assert streams[0].room_attributes.name == "Room APP-3033"
-    assert streams[1].id == "z22OMRPxSdRFBfH_oojGkn___orihaxrdA"
-    assert streams[1].room_attributes.name == "Test BDK"
+    assert streams[0].id == 'ouAS1QXEHtIhXdZq4NzJBX___oscpQFcdA'
+    assert streams[0].room_attributes.name == 'Room APP-3033'
+    assert streams[1].id == 'z22OMRPxSdRFBfH_oojGkn___orihaxrdA'
+    assert streams[1].room_attributes.name == 'Test BDK'
 
 
 @pytest.mark.asyncio
 async def test_add_member_to_room(mocked_api_client, stream_service, room_membership_api):
-    mocked_api_client.call_api.return_value = object_from_json_relative_path("stream/add_member.json")
+    mocked_api_client.call_api.return_value = object_from_json_relative_path('stream/add_member.json')
 
     user_id = 1234456
-    room_id = "room_id"
+    room_id = 'room_id'
     await stream_service.add_member_to_room(user_id, room_id)  # check no exception raised
 
     room_membership_api.v1_room_id_membership_add_post.assert_called_once_with(
@@ -125,10 +125,10 @@ async def test_add_member_to_room(mocked_api_client, stream_service, room_member
 
 @pytest.mark.asyncio
 async def test_remove_member_from_room(mocked_api_client, stream_service, room_membership_api):
-    mocked_api_client.call_api.return_value = object_from_json_relative_path("stream/remove_member.json")
+    mocked_api_client.call_api.return_value = object_from_json_relative_path('stream/remove_member.json')
 
     user_id = 1234456
-    room_id = "room_id"
+    room_id = 'room_id'
     await stream_service.remove_member_from_room(user_id, room_id)  # check no exception raised
 
     room_membership_api.v1_room_id_membership_remove_post.assert_called_once_with(
@@ -137,24 +137,24 @@ async def test_remove_member_from_room(mocked_api_client, stream_service, room_m
 
 @pytest.mark.asyncio
 async def test_share(mocked_api_client, stream_service, share_api):
-    mocked_api_client.call_api.return_value = object_from_json_relative_path("stream/share_article.json")
+    mocked_api_client.call_api.return_value = object_from_json_relative_path('stream/share_article.json')
 
-    stream_id = "stream_id"
+    stream_id = 'stream_id'
     share_content = ShareContent()
     message = await stream_service.share(stream_id, share_content)
 
     share_api.v3_stream_sid_share_post.assert_called_once_with(
         sid=stream_id, share_content=share_content, session_token=SESSION_TOKEN, key_manager_token=KM_TOKEN)
-    assert message.id == "uRcu9fjRALpKLHnPR1k6-3___oh4wwAObQ"
-    assert message.streamId == "ubaSiuUsc_j-_lVQ8vhAz3___opSJdJZdA"
+    assert message.id == 'uRcu9fjRALpKLHnPR1k6-3___oh4wwAObQ'
+    assert message.streamId == 'ubaSiuUsc_j-_lVQ8vhAz3___opSJdJZdA'
 
 
 @pytest.mark.asyncio
 async def test_promote_user(mocked_api_client, stream_service, room_membership_api):
-    mocked_api_client.call_api.return_value = object_from_json_relative_path("stream/member_promoted.json")
+    mocked_api_client.call_api.return_value = object_from_json_relative_path('stream/member_promoted.json')
 
     user_id = 12345
-    room_id = "room_id"
+    room_id = 'room_id'
     await stream_service.promote_user_to_room_owner(user_id, room_id)  # check no exception raised
 
     room_membership_api.v1_room_id_membership_promote_owner_post.assert_called_once_with(
@@ -163,10 +163,10 @@ async def test_promote_user(mocked_api_client, stream_service, room_membership_a
 
 @pytest.mark.asyncio
 async def test_demote_owner(mocked_api_client, stream_service, room_membership_api):
-    mocked_api_client.call_api.return_value = object_from_json_relative_path("stream/member_demoted.json")
+    mocked_api_client.call_api.return_value = object_from_json_relative_path('stream/member_demoted.json')
 
     user_id = 12345
-    room_id = "room_id"
+    room_id = 'room_id'
     await stream_service.demote_owner_to_room_participant(user_id, room_id)  # check no exception raised
 
     room_membership_api.v1_room_id_membership_demote_owner_post.assert_called_once_with(
@@ -174,47 +174,34 @@ async def test_demote_owner(mocked_api_client, stream_service, room_membership_a
 
 
 @pytest.mark.asyncio
-async def test_get_stream(mocked_api_client, stream_service, streams_api):
-    mocked_api_client.call_api.return_value = object_from_json_relative_path("stream/get_stream.json")
-
-    stream_id = "stream_id"
-    stream_attributes = await stream_service.get_stream(stream_id)
-
-    streams_api.v2_streams_sid_info_get.assert_called_once_with(sid=stream_id, session_token=SESSION_TOKEN)
-    assert stream_attributes.id == "ubaSiuUsc_j-_lVQ8vhAz3___opSJdJZdA"
-    assert stream_attributes.roomAttributes.name == "New room name"
-    assert stream_attributes.streamType.type == "ROOM"
-
-
-@pytest.mark.asyncio
 async def test_create_im(mocked_api_client, stream_service, streams_api):
-    mocked_api_client.call_api.return_value = object_from_json_relative_path("stream/create_im_or_mim.json")
+    mocked_api_client.call_api.return_value = object_from_json_relative_path('stream/create_im_or_mim.json')
 
     user_ids = [12334]
     stream = await stream_service.create_im_or_mim(user_ids)
 
     streams_api.v1_im_create_post.assert_called_once_with(uid_list=UserIdList(value=user_ids),
                                                           session_token=SESSION_TOKEN)
-    assert stream.id == "-M8s5WG7K8lAP7cpIiuyTH___oh4zK8EdA"
+    assert stream.id == '-M8s5WG7K8lAP7cpIiuyTH___oh4zK8EdA'
 
 
 @pytest.mark.asyncio
 async def test_create_room(mocked_api_client, stream_service, streams_api):
-    mocked_api_client.call_api.return_value = object_from_json_relative_path("stream/create_room.json")
+    mocked_api_client.call_api.return_value = object_from_json_relative_path('stream/create_room.json')
 
     room_attributes = V3RoomAttributes()
     room_details = await stream_service.create_room(room_attributes)
 
     streams_api.v3_room_create_post.assert_called_once_with(payload=room_attributes, session_token=SESSION_TOKEN)
-    assert room_details.roomAttributes.name == "New fancy room"
-    assert room_details.roomSystemInfo.id == "7X1cP_3wMD4mr6rcp7j26X___oh4uDkVdA"
+    assert room_details.roomAttributes.name == 'New fancy room'
+    assert room_details.roomSystemInfo.id == '7X1cP_3wMD4mr6rcp7j26X___oh4uDkVdA'
 
 
 @pytest.mark.asyncio
 async def test_search_rooms(mocked_api_client, stream_service, streams_api):
-    mocked_api_client.call_api.return_value = object_from_json_relative_path("stream/search_rooms.json")
+    mocked_api_client.call_api.return_value = object_from_json_relative_path('stream/search_rooms.json')
 
-    search_criteria = V2RoomSearchCriteria(query="query")
+    search_criteria = V2RoomSearchCriteria(query='query')
     skip = 1
     limit = 2
     search_results = await stream_service.search_rooms(search_criteria, skip, limit)
@@ -223,14 +210,14 @@ async def test_search_rooms(mocked_api_client, stream_service, streams_api):
                                                             session_token=SESSION_TOKEN)
     assert search_results.count == 1
     assert len(search_results.rooms) == 1
-    assert search_results.rooms[0].roomAttributes.name == "New room name"
+    assert search_results.rooms[0].roomAttributes.name == 'New room name'
 
 
 @pytest.mark.asyncio
 async def test_search_all_rooms(mocked_api_client, stream_service, streams_api):
-    mocked_api_client.call_api.return_value = object_from_json_relative_path("stream/search_rooms.json")
+    mocked_api_client.call_api.return_value = object_from_json_relative_path('stream/search_rooms.json')
 
-    search_criteria = V2RoomSearchCriteria(query="query")
+    search_criteria = V2RoomSearchCriteria(query='query')
     chunk_size = 3
 
     gen = await stream_service.search_all_rooms(search_criteria, chunk_size=chunk_size)
@@ -239,26 +226,26 @@ async def test_search_all_rooms(mocked_api_client, stream_service, streams_api):
     streams_api.v3_room_search_post.assert_called_once_with(query=search_criteria, skip=0, limit=chunk_size,
                                                             session_token=SESSION_TOKEN)
     assert len(search_results) == 1
-    assert search_results[0].roomAttributes.name == "New room name"
+    assert search_results[0].roomAttributes.name == 'New room name'
 
 
 @pytest.mark.asyncio
 async def test_get_room_info(mocked_api_client, stream_service, streams_api):
-    mocked_api_client.call_api.return_value = object_from_json_relative_path("stream/get_room_info.json")
+    mocked_api_client.call_api.return_value = object_from_json_relative_path('stream/get_room_info.json')
 
-    room_id = "room_id"
+    room_id = 'room_id'
     room_detail = await stream_service.get_room_info(room_id)
 
     streams_api.v3_room_id_info_get.assert_called_once_with(id=room_id, session_token=SESSION_TOKEN)
-    assert room_detail.roomAttributes.name == "New room name"
-    assert room_detail.roomSystemInfo.id == "ubaSiuUsc_j-_lVQ8vhAz3___opSJdJZdA"
+    assert room_detail.roomAttributes.name == 'New room name'
+    assert room_detail.roomSystemInfo.id == 'ubaSiuUsc_j-_lVQ8vhAz3___opSJdJZdA'
 
 
 @pytest.mark.asyncio
 async def test_set_room_active(mocked_api_client, stream_service, streams_api):
-    mocked_api_client.call_api.return_value = object_from_json_relative_path("stream/deactivate_room.json")
+    mocked_api_client.call_api.return_value = object_from_json_relative_path('stream/deactivate_room.json')
 
-    room_id = "room_id"
+    room_id = 'room_id'
     active = False
     room_detail = await stream_service.set_room_active(room_id, active)
 
@@ -269,35 +256,35 @@ async def test_set_room_active(mocked_api_client, stream_service, streams_api):
 
 @pytest.mark.asyncio
 async def test_update_room(mocked_api_client, stream_service, streams_api):
-    mocked_api_client.call_api.return_value = object_from_json_relative_path("stream/update_room.json")
+    mocked_api_client.call_api.return_value = object_from_json_relative_path('stream/update_room.json')
 
-    room_id = "room_id"
+    room_id = 'room_id'
     room_attributes = V3RoomAttributes()
     room_details = await stream_service.update_room(room_id, room_attributes)
 
     streams_api.v3_room_id_update_post.assert_called_once_with(id=room_id, payload=room_attributes,
                                                                session_token=SESSION_TOKEN)
-    assert room_details.roomAttributes.name == "Test bot room"
-    assert room_details.roomSystemInfo.id == "ubaSiuUsc_j-_lVQ8vhAz3___opSJdJZdA"
+    assert room_details.roomAttributes.name == 'Test bot room'
+    assert room_details.roomSystemInfo.id == 'ubaSiuUsc_j-_lVQ8vhAz3___opSJdJZdA'
 
 
 @pytest.mark.asyncio
 async def test_create_im_admin(mocked_api_client, stream_service, streams_api):
-    mocked_api_client.call_api.return_value = object_from_json_relative_path("stream/create_im_or_mim.json")
+    mocked_api_client.call_api.return_value = object_from_json_relative_path('stream/create_im_or_mim.json')
 
     user_ids = [12334]
     stream = await stream_service.create_im_admin(user_ids)
 
     streams_api.v1_admin_im_create_post.assert_called_once_with(uid_list=UserIdList(value=user_ids),
                                                                 session_token=SESSION_TOKEN)
-    assert stream.id == "-M8s5WG7K8lAP7cpIiuyTH___oh4zK8EdA"
+    assert stream.id == '-M8s5WG7K8lAP7cpIiuyTH___oh4zK8EdA'
 
 
 @pytest.mark.asyncio
 async def test_set_room_active_admin(mocked_api_client, stream_service, streams_api):
-    mocked_api_client.call_api.return_value = object_from_json_relative_path("stream/deactivate_room.json")
+    mocked_api_client.call_api.return_value = object_from_json_relative_path('stream/deactivate_room.json')
 
-    room_id = "room_id"
+    room_id = 'room_id'
     active = False
     room_detail = await stream_service.set_room_active_admin(room_id, active)
 
@@ -308,7 +295,7 @@ async def test_set_room_active_admin(mocked_api_client, stream_service, streams_
 
 @pytest.mark.asyncio
 async def test_list_streams_admin(mocked_api_client, stream_service, streams_api):
-    mocked_api_client.call_api.return_value = get_deserialized_object_from_json("stream/list_streams_admin.json",
+    mocked_api_client.call_api.return_value = get_deserialized_object_from_json('stream/list_streams_admin.json',
                                                                                 V2AdminStreamList)
 
     stream_filter = V2AdminStreamFilter()
@@ -320,13 +307,13 @@ async def test_list_streams_admin(mocked_api_client, stream_service, streams_api
                                                                    session_token=SESSION_TOKEN)
     assert streams.limit == 2
     assert len(streams.streams.value) == 2
-    assert streams.streams.value[0].id == "hpRd80zAUnLv3NMhLVF3Ln___o3ULKRDdA"
-    assert streams.streams.value[1].id == "6hEzTqQjVPLLE9KgXLvsKn___o3TtL3ddA"
+    assert streams.streams.value[0].id == 'hpRd80zAUnLv3NMhLVF3Ln___o3ULKRDdA'
+    assert streams.streams.value[1].id == '6hEzTqQjVPLLE9KgXLvsKn___o3TtL3ddA'
 
 
 @pytest.mark.asyncio
 async def test_list_all_streams_admin(mocked_api_client, stream_service, streams_api):
-    mocked_api_client.call_api.return_value = get_deserialized_object_from_json("stream/list_streams_admin.json",
+    mocked_api_client.call_api.return_value = get_deserialized_object_from_json('stream/list_streams_admin.json',
                                                                                 V2AdminStreamList)
 
     stream_filter = V2AdminStreamFilter()
@@ -338,16 +325,16 @@ async def test_list_all_streams_admin(mocked_api_client, stream_service, streams
     streams_api.v2_admin_streams_list_post.assert_called_once_with(filter=stream_filter, skip=0, limit=limit,
                                                                    session_token=SESSION_TOKEN)
     assert len(streams) == 2
-    assert streams[0].id == "hpRd80zAUnLv3NMhLVF3Ln___o3ULKRDdA"
-    assert streams[1].id == "6hEzTqQjVPLLE9KgXLvsKn___o3TtL3ddA"
+    assert streams[0].id == 'hpRd80zAUnLv3NMhLVF3Ln___o3ULKRDdA'
+    assert streams[1].id == '6hEzTqQjVPLLE9KgXLvsKn___o3TtL3ddA'
 
 
 @pytest.mark.asyncio
 async def test_list_stream_members(mocked_api_client, stream_service, streams_api):
-    mocked_api_client.call_api.return_value = get_deserialized_object_from_json("stream/list_stream_members.json",
+    mocked_api_client.call_api.return_value = get_deserialized_object_from_json('stream/list_stream_members.json',
                                                                                 V2MembershipList)
 
-    stream_id = "stream_id"
+    stream_id = 'stream_id'
     skip = 1
     limit = 2
     members = await stream_service.list_stream_members(stream_id, skip, limit)
@@ -362,10 +349,10 @@ async def test_list_stream_members(mocked_api_client, stream_service, streams_ap
 
 @pytest.mark.asyncio
 async def test_list_all_stream_members(mocked_api_client, stream_service, streams_api):
-    mocked_api_client.call_api.return_value = get_deserialized_object_from_json("stream/list_stream_members.json",
+    mocked_api_client.call_api.return_value = get_deserialized_object_from_json('stream/list_stream_members.json',
                                                                                 V2MembershipList)
 
-    stream_id = "stream_id"
+    stream_id = 'stream_id'
     limit = 5
     gen = await stream_service.list_all_stream_members(stream_id, limit)
     members = [m async for m in gen]
@@ -379,9 +366,9 @@ async def test_list_all_stream_members(mocked_api_client, stream_service, stream
 
 @pytest.mark.asyncio
 async def test_list_room_members(mocked_api_client, stream_service, room_membership_api):
-    mocked_api_client.call_api.return_value = object_from_json_relative_path("stream/list_room_members.json")
+    mocked_api_client.call_api.return_value = object_from_json_relative_path('stream/list_room_members.json')
 
-    room_id = "room_id"
+    room_id = 'room_id'
     members = await stream_service.list_room_members(room_id)
 
     room_membership_api.v2_room_id_membership_list_get.assert_called_once_with(id=room_id, session_token=SESSION_TOKEN)

--- a/tests/core/service/user/user_service_test.py
+++ b/tests/core/service/user/user_service_test.py
@@ -1,9 +1,10 @@
 from unittest.mock import MagicMock, AsyncMock
 
-import pytest
 import base64
+import pytest
 
 from symphony.bdk.core.auth.auth_session import AuthSession
+from symphony.bdk.core.service.user.model.delegate_action_enum import DelegateActionEnum
 from symphony.bdk.core.service.user.model.role_id import RoleId
 from symphony.bdk.core.service.user.user_service import UserService
 from symphony.bdk.gen.agent_api.audit_trail_api import AuditTrailApi
@@ -18,50 +19,48 @@ from symphony.bdk.gen.pod_model.user_filter import UserFilter
 from symphony.bdk.gen.pod_model.user_id_list import UserIdList
 from symphony.bdk.gen.pod_model.user_search_filter import UserSearchFilter
 from symphony.bdk.gen.pod_model.user_search_query import UserSearchQuery
-from symphony.bdk.gen.pod_model.user_search_results import UserSearchResults
 from symphony.bdk.gen.pod_model.v2_user_detail_list import V2UserDetailList
-from tests.utils.resource_utils import object_from_json_relative_path, object_from_json, get_resource_filepath, \
-    get_deserialized_object_from_json
 from symphony.bdk.gen.pod_model.delegate_action import DelegateAction
-from symphony.bdk.core.service.user.model.delegate_action_enum import DelegateActionEnum
 from symphony.bdk.gen.pod_model.feature_list import FeatureList
 from symphony.bdk.gen.pod_model.feature import Feature
 from symphony.bdk.gen.pod_model.user_status import UserStatus
 from symphony.bdk.gen.pod_model.v2_user_create import V2UserCreate
 from symphony.bdk.gen.pod_model.v2_user_attributes import V2UserAttributes
 from symphony.bdk.gen.pod_model.user_suspension import UserSuspension
+from tests.utils.resource_utils import object_from_json_relative_path, object_from_json, get_resource_filepath, \
+    get_deserialized_object_from_json
 
 
-@pytest.fixture()
-def auth_session():
+@pytest.fixture(name='auth_session')
+def fixture_auth_session():
     auth_session = AuthSession(None)
     auth_session.session_token = 'session_token'
     auth_session.key_manager_token = 'km_token'
     return auth_session
 
 
-@pytest.fixture()
-def user_api():
+@pytest.fixture(name='user_api')
+def fixture_user_api():
     return MagicMock(UserApi)
 
 
-@pytest.fixture()
-def users_api():
+@pytest.fixture(name='users_api')
+def fixture_users_api():
     return MagicMock(UsersApi)
 
 
-@pytest.fixture()
-def audit_trail_api():
+@pytest.fixture(name='audit_trail_api')
+def fixture_audit_trail_api():
     return MagicMock(AuditTrailApi)
 
 
-@pytest.fixture()
-def system_api():
+@pytest.fixture(name='system_api')
+def fixture_system_api():
     return MagicMock(SystemApi)
 
 
-@pytest.fixture()
-def user_service(user_api, users_api, audit_trail_api, system_api, auth_session):
+@pytest.fixture(name='user_service')
+def fixture_user_service(user_api, users_api, audit_trail_api, system_api, auth_session):
     service = UserService(
         user_api,
         users_api,
@@ -75,13 +74,13 @@ def user_service(user_api, users_api, audit_trail_api, system_api, auth_session)
 @pytest.mark.asyncio
 async def test_list_users_by_ids(users_api, user_service):
     users_api.v3_users_get = AsyncMock()
-    users_api.v3_users_get.return_value = object_from_json_relative_path("user/list_user.json")
+    users_api.v3_users_get.return_value = object_from_json_relative_path('user/list_user.json')
     users_list = await user_service.list_users_by_ids([15942919536460, 15942919536461], active=True)
 
     users_api.v3_users_get.assert_called_with(
         uid='15942919536460,15942919536461',
         local=False,
-        session_token="session_token",
+        session_token='session_token',
         active=True
     )
     assert len(users_list.users) == 2
@@ -92,7 +91,7 @@ async def test_list_users_by_ids(users_api, user_service):
 @pytest.mark.asyncio
 async def test_list_users_by_emails(users_api, user_service):
     users_api.v3_users_get = AsyncMock()
-    users_api.v3_users_get.return_value = object_from_json_relative_path("user/list_user.json")
+    users_api.v3_users_get.return_value = object_from_json_relative_path('user/list_user.json')
     users_list = await user_service.list_users_by_emails(
         ['technicalwriter@symphony.com', 'serviceaccount@symphony.com'],
         active=True
@@ -101,7 +100,7 @@ async def test_list_users_by_emails(users_api, user_service):
     users_api.v3_users_get.assert_called_with(
         email='technicalwriter@symphony.com,serviceaccount@symphony.com',
         local=False,
-        session_token="session_token",
+        session_token='session_token',
         active=True
     )
     assert len(users_list.users) == 2
@@ -112,7 +111,7 @@ async def test_list_users_by_emails(users_api, user_service):
 @pytest.mark.asyncio
 async def test_list_users_by_usernames(users_api, user_service):
     users_api.v3_users_get = AsyncMock()
-    users_api.v3_users_get.return_value = object_from_json_relative_path("user/list_user.json")
+    users_api.v3_users_get.return_value = object_from_json_relative_path('user/list_user.json')
     users_list = await user_service.list_users_by_usernames(
         ['tw', 'SA'],
         active=True
@@ -121,7 +120,7 @@ async def test_list_users_by_usernames(users_api, user_service):
     users_api.v3_users_get.assert_called_with(
         username='tw,SA',
         local=True,
-        session_token="session_token",
+        session_token='session_token',
         active=True
     )
 
@@ -133,7 +132,7 @@ async def test_list_users_by_usernames(users_api, user_service):
 @pytest.mark.asyncio
 async def test_search_users(users_api, user_service):
     users_api.v1_user_search_post = AsyncMock()
-    users_api.v1_user_search_post.return_value = object_from_json_relative_path("user/search_user.json")
+    users_api.v1_user_search_post.return_value = object_from_json_relative_path('user/search_user.json')
     query = UserSearchQuery(query='jane', filters=UserSearchFilter(title='Sales Manager', company='Symphony'))
 
     result = await user_service.search_users(query)
@@ -153,7 +152,7 @@ async def test_search_users(users_api, user_service):
 @pytest.mark.asyncio
 async def test_search_all_users(users_api, user_service):
     users_api.v1_user_search_post = AsyncMock()
-    users_api.v1_user_search_post.return_value = object_from_json_relative_path("user/search_user.json")
+    users_api.v1_user_search_post.return_value = object_from_json_relative_path('user/search_user.json')
     query = UserSearchQuery(query='jane', filters=UserSearchFilter(title='Sales Manager', company='Symphony'))
 
     gen = await user_service.search_all_users(query)
@@ -184,7 +183,7 @@ async def test_follow_user(user_api, user_service):
     user_api.v1_user_uid_follow_post.assert_called_with(
         uid=12345,
         uid_list=FollowersList(followers=UserIdList(value=[1234, 2345])),
-        session_token="session_token"
+        session_token='session_token'
     )
 
 
@@ -203,20 +202,20 @@ async def test_unfollow_user(user_api, user_service):
     user_api.v1_user_uid_unfollow_post.assert_called_with(
         uid=12345,
         uid_list=FollowersList(followers=UserIdList(value=[1234, 2345])),
-        session_token="session_token"
+        session_token='session_token'
     )
 
 
 @pytest.mark.asyncio
 async def test_get_user_detail(user_api, user_service):
     user_api.v2_admin_user_uid_get = AsyncMock()
-    user_api.v2_admin_user_uid_get.return_value = object_from_json_relative_path("user/user_detail.json")
+    user_api.v2_admin_user_uid_get.return_value = object_from_json_relative_path('user/user_detail.json')
 
     user_detail = await user_service.get_user_detail(7215545078461)
 
     user_api.v2_admin_user_uid_get.assert_called_with(
         uid=7215545078461,
-        session_token="session_token"
+        session_token='session_token'
     )
 
     assert user_detail.userAttributes.userName == 'johndoe'
@@ -227,7 +226,7 @@ async def test_get_user_detail(user_api, user_service):
 @pytest.mark.asyncio
 async def test_list_user_details(user_api, user_service):
     user_api.v2_admin_user_list_get = AsyncMock()
-    user_api.v2_admin_user_list_get.return_value = get_deserialized_object_from_json("user/list_user_detail.json",
+    user_api.v2_admin_user_list_get.return_value = get_deserialized_object_from_json('user/list_user_detail.json',
                                                                                      V2UserDetailList)
 
     user_detail_list = await user_service.list_user_details()
@@ -235,18 +234,18 @@ async def test_list_user_details(user_api, user_service):
     user_api.v2_admin_user_list_get.assert_called_with(
         skip=0,
         limit=50,
-        session_token="session_token"
+        session_token='session_token'
     )
 
     assert len(user_detail_list) == 5
-    assert user_detail_list[0].user_attributes.user_name == "agentservice"
+    assert user_detail_list[0].user_attributes.user_name == 'agentservice'
     assert user_detail_list[1].user_system_info.id == 9826885173258
 
 
 @pytest.mark.asyncio
 async def test_list_all_user_details(user_api, user_service):
     user_api.v2_admin_user_list_get = AsyncMock()
-    user_api.v2_admin_user_list_get.return_value = get_deserialized_object_from_json("user/list_user_detail.json",
+    user_api.v2_admin_user_list_get.return_value = get_deserialized_object_from_json('user/list_user_detail.json',
                                                                                      V2UserDetailList)
 
     gen = await user_service.list_all_user_details()
@@ -255,20 +254,20 @@ async def test_list_all_user_details(user_api, user_service):
     user_api.v2_admin_user_list_get.assert_called_with(
         skip=0,
         limit=50,
-        session_token="session_token"
+        session_token='session_token'
     )
 
     assert len(user_detail_list) == 5
-    assert user_detail_list[0].user_attributes.user_name == "agentservice"
+    assert user_detail_list[0].user_attributes.user_name == 'agentservice'
     assert user_detail_list[1].user_system_info.id == 9826885173258
 
 
 @pytest.mark.asyncio
 async def test_list_user_details_by_filter(user_api, user_service):
     user_api.v1_admin_user_find_post = AsyncMock()
-    user_api.v1_admin_user_find_post.return_value = get_deserialized_object_from_json("user/list_user_by_filter.json",
+    user_api.v1_admin_user_find_post.return_value = get_deserialized_object_from_json('user/list_user_by_filter.json',
                                                                                       UserDetailList)
-    user_filter = UserFilter(status="ENABLED")
+    user_filter = UserFilter(status='ENABLED')
 
     user_detail_list = await user_service.list_user_details_by_filter(user_filter)
 
@@ -276,20 +275,20 @@ async def test_list_user_details_by_filter(user_api, user_service):
         skip=0,
         limit=50,
         payload=user_filter,
-        session_token="session_token"
+        session_token='session_token'
     )
 
     assert len(user_detail_list) == 3
-    assert user_detail_list[0].user_attributes.user_name == "agentservice"
+    assert user_detail_list[0].user_attributes.user_name == 'agentservice'
     assert user_detail_list[1].user_system_info.id == 9826885173258
 
 
 @pytest.mark.asyncio
 async def test_list_all_user_details_by_filter(user_api, user_service):
     user_api.v1_admin_user_find_post = AsyncMock()
-    user_api.v1_admin_user_find_post.return_value = get_deserialized_object_from_json("user/list_user_by_filter.json",
+    user_api.v1_admin_user_find_post.return_value = get_deserialized_object_from_json('user/list_user_by_filter.json',
                                                                                       UserDetailList)
-    user_filter = UserFilter(status="ENABLED")
+    user_filter = UserFilter(status='ENABLED')
 
     gen = await user_service.list_all_user_details_by_filter(user_filter)
     user_detail_list = [u async for u in gen]
@@ -298,11 +297,11 @@ async def test_list_all_user_details_by_filter(user_api, user_service):
         skip=0,
         limit=50,
         payload=user_filter,
-        session_token="session_token"
+        session_token='session_token'
     )
 
     assert len(user_detail_list) == 3
-    assert user_detail_list[0].user_attributes.user_name == "agentservice"
+    assert user_detail_list[0].user_attributes.user_name == 'agentservice'
     assert user_detail_list[1].user_system_info.id == 9826885173258
 
 
@@ -321,7 +320,7 @@ async def test_add_role(user_api, user_service):
     user_api.v1_admin_user_uid_roles_add_post.assert_called_with(
         uid=1234,
         payload=StringId(id='INDIVIDUAL'),
-        session_token="session_token"
+        session_token='session_token'
     )
 
 
@@ -329,12 +328,12 @@ async def test_add_role(user_api, user_service):
 async def test_list_roles(system_api, user_service):
     system_api.v1_admin_system_roles_list_get = AsyncMock()
     system_api.v1_admin_system_roles_list_get.return_value = \
-        object_from_json_relative_path("user/list_roles.json")
+        object_from_json_relative_path('user/list_roles.json')
 
     role_list = await user_service.list_roles()
 
     system_api.v1_admin_system_roles_list_get.assert_called_with(
-        session_token="session_token"
+        session_token='session_token'
     )
 
     assert len(role_list) == 12
@@ -357,7 +356,7 @@ async def test_remove_role(user_api, user_service):
     user_api.v1_admin_user_uid_roles_remove_post.assert_called_with(
         uid=1234,
         payload=StringId(id='INDIVIDUAL'),
-        session_token="session_token"
+        session_token='session_token'
     )
 
 
@@ -365,13 +364,13 @@ async def test_remove_role(user_api, user_service):
 async def test_get_avatar(user_api, user_service):
     user_api.v1_admin_user_uid_avatar_get = AsyncMock()
     user_api.v1_admin_user_uid_avatar_get.return_value = \
-        object_from_json_relative_path("user/list_avatar.json")
+        object_from_json_relative_path('user/list_avatar.json')
 
     avatar_list = await user_service.get_avatar(1234)
 
     user_api.v1_admin_user_uid_avatar_get.assert_called_with(
         uid=1234,
-        session_token="session_token"
+        session_token='session_token'
     )
 
     assert len(avatar_list) == 5
@@ -389,21 +388,21 @@ async def test_update_avatar(user_api, user_service):
         '}'
     )
 
-    await user_service.update_avatar(1234, "image_string")
+    await user_service.update_avatar(1234, 'image_string')
     user_api.v1_admin_user_uid_avatar_update_post.assert_called_with(
         uid=1234,
-        payload=AvatarUpdate(image="image_string"),
-        session_token="session_token"
+        payload=AvatarUpdate(image='image_string'),
+        session_token='session_token'
     )
 
-    with open(get_resource_filepath('user/FINOS_icon_rgb.png', as_text=True), 'rb') as f:
-        avatar_bytes = f.read()
+    with open(get_resource_filepath('user/FINOS_icon_rgb.png', as_text=True), 'rb') as file:
+        avatar_bytes = file.read()
         await user_service.update_avatar(1234, avatar_bytes)
 
         user_api.v1_admin_user_uid_avatar_update_post.assert_called_with(
             uid=1234,
             payload=AvatarUpdate(image=str(base64.standard_b64encode(avatar_bytes))),
-            session_token="session_token"
+            session_token='session_token'
         )
 
 
@@ -427,7 +426,7 @@ async def test_get_disclaimer(user_api, user_service):
 
     user_api.v1_admin_user_uid_disclaimer_get.assert_called_with(
         uid=1234,
-        session_token="session_token"
+        session_token='session_token'
     )
 
     assert disclaimer.id == '571d2052e4b042aaf06d2e7a'
@@ -448,7 +447,7 @@ async def test_remove_disclaimer(user_api, user_service):
 
     user_api.v1_admin_user_uid_disclaimer_delete.assert_called_with(
         uid=1234,
-        session_token="session_token"
+        session_token='session_token'
     )
 
 
@@ -585,7 +584,7 @@ async def test_update_status(user_api, user_service):
         '   "message": "OK"'
         '}'
     )
-    status = UserStatus(status="ENABLED")
+    status = UserStatus(status='ENABLED')
 
     await user_service.update_status(1234, status)
 
@@ -599,7 +598,7 @@ async def test_update_status(user_api, user_service):
 @pytest.mark.asyncio
 async def test_list_user_followers(user_api, user_service):
     user_api.v1_user_uid_followers_get = AsyncMock()
-    user_api.v1_user_uid_followers_get.return_value = object_from_json_relative_path("user/list_user_followers.json")
+    user_api.v1_user_uid_followers_get.return_value = object_from_json_relative_path('user/list_user_followers.json')
 
     follower_list = await user_service.list_user_followers(1234, before=4, after=1)
 
@@ -617,9 +616,9 @@ async def test_list_user_followers(user_api, user_service):
 
 
 @pytest.mark.asyncio
-async def test_list_user_followers(user_api, user_service):
+async def test_list_all_user_followers(user_api, user_service):
     user_api.v1_user_uid_followers_get = AsyncMock()
-    user_api.v1_user_uid_followers_get.return_value = object_from_json_relative_path("user/list_user_followers.json")
+    user_api.v1_user_uid_followers_get.return_value = object_from_json_relative_path('user/list_user_followers.json')
 
     gen = await user_service.list_all_user_followers(1234, max_number=2)
     follower_list = [uid async for uid in gen]
@@ -627,7 +626,7 @@ async def test_list_user_followers(user_api, user_service):
     user_api.v1_user_uid_followers_get.assert_called_with(
         uid=1234,
         limit=100,
-        session_token='session_token'
+        session_token='session_token',
     )
 
     assert len(follower_list) == 2
@@ -638,7 +637,7 @@ async def test_list_user_followers(user_api, user_service):
 @pytest.mark.asyncio
 async def test_list_users_following(user_api, user_service):
     user_api.v1_user_uid_following_get = AsyncMock()
-    user_api.v1_user_uid_following_get.return_value = object_from_json_relative_path("user/list_users_following.json")
+    user_api.v1_user_uid_following_get.return_value = object_from_json_relative_path('user/list_users_following.json')
 
     following_user_list = await user_service.list_users_following(1234, before=4, after=1)
 
@@ -658,7 +657,7 @@ async def test_list_users_following(user_api, user_service):
 @pytest.mark.asyncio
 async def test_list_all_users_following(user_api, user_service):
     user_api.v1_user_uid_following_get = AsyncMock()
-    user_api.v1_user_uid_following_get.return_value = object_from_json_relative_path("user/list_users_following.json")
+    user_api.v1_user_uid_following_get.return_value = object_from_json_relative_path('user/list_users_following.json')
 
     gen = await user_service.list_all_users_following(1234, max_number=2)
     following_user_list = [uid async for uid in gen]
@@ -677,7 +676,7 @@ async def test_list_all_users_following(user_api, user_service):
 @pytest.mark.asyncio
 async def test_create(user_api, user_service):
     user_api.v2_admin_user_create_post = AsyncMock()
-    user_api.v2_admin_user_create_post.return_value = object_from_json_relative_path("user/user_detail.json")
+    user_api.v2_admin_user_create_post.return_value = object_from_json_relative_path('user/user_detail.json')
 
     user_create = V2UserCreate()
     user_detail = await user_service.create(user_create)
@@ -695,7 +694,7 @@ async def test_create(user_api, user_service):
 @pytest.mark.asyncio
 async def test_update(user_api, user_service):
     user_api.v2_admin_user_uid_update_post = AsyncMock()
-    user_api.v2_admin_user_uid_update_post.return_value = object_from_json_relative_path("user/user_detail.json")
+    user_api.v2_admin_user_uid_update_post.return_value = object_from_json_relative_path('user/user_detail.json')
 
     user_attribute = V2UserAttributes()
 
@@ -716,7 +715,7 @@ async def test_update(user_api, user_service):
 async def test_list_audit_trail(audit_trail_api, user_service):
     audit_trail_api.v1_audittrail_privilegeduser_get = AsyncMock()
     audit_trail_api.v1_audittrail_privilegeduser_get.return_value = \
-        object_from_json_relative_path("user/list_audit_trail.json")
+        object_from_json_relative_path('user/list_audit_trail.json')
 
     audit_trail_initiator_list = \
         await user_service.list_audit_trail(1234, 2345, 12345, RoleId.SUPER_ADMINISTRATOR, before=1, after=4)

--- a/tests/core/service/user/user_service_test.py
+++ b/tests/core/service/user/user_service_test.py
@@ -31,35 +31,35 @@ from tests.utils.resource_utils import object_from_json_relative_path, object_fr
     get_deserialized_object_from_json
 
 
-@pytest.fixture(name='auth_session')
+@pytest.fixture(name="auth_session")
 def fixture_auth_session():
     auth_session = AuthSession(None)
-    auth_session.session_token = 'session_token'
-    auth_session.key_manager_token = 'km_token'
+    auth_session.session_token = "session_token"
+    auth_session.key_manager_token = "km_token"
     return auth_session
 
 
-@pytest.fixture(name='user_api')
+@pytest.fixture(name="user_api")
 def fixture_user_api():
     return MagicMock(UserApi)
 
 
-@pytest.fixture(name='users_api')
+@pytest.fixture(name="users_api")
 def fixture_users_api():
     return MagicMock(UsersApi)
 
 
-@pytest.fixture(name='audit_trail_api')
+@pytest.fixture(name="audit_trail_api")
 def fixture_audit_trail_api():
     return MagicMock(AuditTrailApi)
 
 
-@pytest.fixture(name='system_api')
+@pytest.fixture(name="system_api")
 def fixture_system_api():
     return MagicMock(SystemApi)
 
 
-@pytest.fixture(name='user_service')
+@pytest.fixture(name="user_service")
 def fixture_user_service(user_api, users_api, audit_trail_api, system_api, auth_session):
     service = UserService(
         user_api,
@@ -74,66 +74,66 @@ def fixture_user_service(user_api, users_api, audit_trail_api, system_api, auth_
 @pytest.mark.asyncio
 async def test_list_users_by_ids(users_api, user_service):
     users_api.v3_users_get = AsyncMock()
-    users_api.v3_users_get.return_value = object_from_json_relative_path('user/list_user.json')
+    users_api.v3_users_get.return_value = object_from_json_relative_path("user/list_user.json")
     users_list = await user_service.list_users_by_ids([15942919536460, 15942919536461], active=True)
 
     users_api.v3_users_get.assert_called_with(
-        uid='15942919536460,15942919536461',
+        uid="15942919536460,15942919536461",
         local=False,
-        session_token='session_token',
+        session_token="session_token",
         active=True
     )
     assert len(users_list.users) == 2
     assert len(users_list.errors) == 2
-    assert users_list.users[0].username == 'tw'
+    assert users_list.users[0].username == "tw"
 
 
 @pytest.mark.asyncio
 async def test_list_users_by_emails(users_api, user_service):
     users_api.v3_users_get = AsyncMock()
-    users_api.v3_users_get.return_value = object_from_json_relative_path('user/list_user.json')
+    users_api.v3_users_get.return_value = object_from_json_relative_path("user/list_user.json")
     users_list = await user_service.list_users_by_emails(
-        ['technicalwriter@symphony.com', 'serviceaccount@symphony.com'],
+        ["technicalwriter@symphony.com", "serviceaccount@symphony.com"],
         active=True
     )
 
     users_api.v3_users_get.assert_called_with(
-        email='technicalwriter@symphony.com,serviceaccount@symphony.com',
+        email="technicalwriter@symphony.com,serviceaccount@symphony.com",
         local=False,
-        session_token='session_token',
+        session_token="session_token",
         active=True
     )
     assert len(users_list.users) == 2
     assert len(users_list.errors) == 2
-    assert users_list.users[0].username == 'tw'
+    assert users_list.users[0].username == "tw"
 
 
 @pytest.mark.asyncio
 async def test_list_users_by_usernames(users_api, user_service):
     users_api.v3_users_get = AsyncMock()
-    users_api.v3_users_get.return_value = object_from_json_relative_path('user/list_user.json')
+    users_api.v3_users_get.return_value = object_from_json_relative_path("user/list_user.json")
     users_list = await user_service.list_users_by_usernames(
-        ['tw', 'SA'],
+        ["tw", "SA"],
         active=True
     )
 
     users_api.v3_users_get.assert_called_with(
-        username='tw,SA',
+        username="tw,SA",
         local=True,
-        session_token='session_token',
+        session_token="session_token",
         active=True
     )
 
     assert len(users_list.users) == 2
     assert len(users_list.errors) == 2
-    assert users_list.users[0].emailAddress == 'technicalwriter@symphony.com'
+    assert users_list.users[0].emailAddress == "technicalwriter@symphony.com"
 
 
 @pytest.mark.asyncio
 async def test_search_users(users_api, user_service):
     users_api.v1_user_search_post = AsyncMock()
-    users_api.v1_user_search_post.return_value = object_from_json_relative_path('user/search_user.json')
-    query = UserSearchQuery(query='jane', filters=UserSearchFilter(title='Sales Manager', company='Symphony'))
+    users_api.v1_user_search_post.return_value = object_from_json_relative_path("user/search_user.json")
+    query = UserSearchQuery(query="jane", filters=UserSearchFilter(title="Sales Manager", company="Symphony"))
 
     result = await user_service.search_users(query)
 
@@ -142,7 +142,7 @@ async def test_search_users(users_api, user_service):
         local=False,
         skip=0,
         limit=50,
-        session_token='session_token'
+        session_token="session_token"
     )
     assert result.count == 1
     assert len(result.users) == 1
@@ -152,8 +152,8 @@ async def test_search_users(users_api, user_service):
 @pytest.mark.asyncio
 async def test_search_all_users(users_api, user_service):
     users_api.v1_user_search_post = AsyncMock()
-    users_api.v1_user_search_post.return_value = object_from_json_relative_path('user/search_user.json')
-    query = UserSearchQuery(query='jane', filters=UserSearchFilter(title='Sales Manager', company='Symphony'))
+    users_api.v1_user_search_post.return_value = object_from_json_relative_path("user/search_user.json")
+    query = UserSearchQuery(query="jane", filters=UserSearchFilter(title="Sales Manager", company="Symphony"))
 
     gen = await user_service.search_all_users(query)
     result = [u async for u in gen]
@@ -163,7 +163,7 @@ async def test_search_all_users(users_api, user_service):
         local=False,
         skip=0,
         limit=50,
-        session_token='session_token'
+        session_token="session_token"
     )
     assert len(result) == 1
     assert result[0].id == 13056700581099
@@ -183,7 +183,7 @@ async def test_follow_user(user_api, user_service):
     user_api.v1_user_uid_follow_post.assert_called_with(
         uid=12345,
         uid_list=FollowersList(followers=UserIdList(value=[1234, 2345])),
-        session_token='session_token'
+        session_token="session_token"
     )
 
 
@@ -202,31 +202,31 @@ async def test_unfollow_user(user_api, user_service):
     user_api.v1_user_uid_unfollow_post.assert_called_with(
         uid=12345,
         uid_list=FollowersList(followers=UserIdList(value=[1234, 2345])),
-        session_token='session_token'
+        session_token="session_token"
     )
 
 
 @pytest.mark.asyncio
 async def test_get_user_detail(user_api, user_service):
     user_api.v2_admin_user_uid_get = AsyncMock()
-    user_api.v2_admin_user_uid_get.return_value = object_from_json_relative_path('user/user_detail.json')
+    user_api.v2_admin_user_uid_get.return_value = object_from_json_relative_path("user/user_detail.json")
 
     user_detail = await user_service.get_user_detail(7215545078461)
 
     user_api.v2_admin_user_uid_get.assert_called_with(
         uid=7215545078461,
-        session_token='session_token'
+        session_token="session_token"
     )
 
-    assert user_detail.userAttributes.userName == 'johndoe'
-    assert user_detail.userSystemInfo.status == 'ENABLED'
+    assert user_detail.userAttributes.userName == "johndoe"
+    assert user_detail.userSystemInfo.status == "ENABLED"
     assert len(user_detail.roles) == 6
 
 
 @pytest.mark.asyncio
 async def test_list_user_details(user_api, user_service):
     user_api.v2_admin_user_list_get = AsyncMock()
-    user_api.v2_admin_user_list_get.return_value = get_deserialized_object_from_json('user/list_user_detail.json',
+    user_api.v2_admin_user_list_get.return_value = get_deserialized_object_from_json("user/list_user_detail.json",
                                                                                      V2UserDetailList)
 
     user_detail_list = await user_service.list_user_details()
@@ -234,18 +234,18 @@ async def test_list_user_details(user_api, user_service):
     user_api.v2_admin_user_list_get.assert_called_with(
         skip=0,
         limit=50,
-        session_token='session_token'
+        session_token="session_token"
     )
 
     assert len(user_detail_list) == 5
-    assert user_detail_list[0].user_attributes.user_name == 'agentservice'
+    assert user_detail_list[0].user_attributes.user_name == "agentservice"
     assert user_detail_list[1].user_system_info.id == 9826885173258
 
 
 @pytest.mark.asyncio
 async def test_list_all_user_details(user_api, user_service):
     user_api.v2_admin_user_list_get = AsyncMock()
-    user_api.v2_admin_user_list_get.return_value = get_deserialized_object_from_json('user/list_user_detail.json',
+    user_api.v2_admin_user_list_get.return_value = get_deserialized_object_from_json("user/list_user_detail.json",
                                                                                      V2UserDetailList)
 
     gen = await user_service.list_all_user_details()
@@ -254,20 +254,20 @@ async def test_list_all_user_details(user_api, user_service):
     user_api.v2_admin_user_list_get.assert_called_with(
         skip=0,
         limit=50,
-        session_token='session_token'
+        session_token="session_token"
     )
 
     assert len(user_detail_list) == 5
-    assert user_detail_list[0].user_attributes.user_name == 'agentservice'
+    assert user_detail_list[0].user_attributes.user_name == "agentservice"
     assert user_detail_list[1].user_system_info.id == 9826885173258
 
 
 @pytest.mark.asyncio
 async def test_list_user_details_by_filter(user_api, user_service):
     user_api.v1_admin_user_find_post = AsyncMock()
-    user_api.v1_admin_user_find_post.return_value = get_deserialized_object_from_json('user/list_user_by_filter.json',
+    user_api.v1_admin_user_find_post.return_value = get_deserialized_object_from_json("user/list_user_by_filter.json",
                                                                                       UserDetailList)
-    user_filter = UserFilter(status='ENABLED')
+    user_filter = UserFilter(status="ENABLED")
 
     user_detail_list = await user_service.list_user_details_by_filter(user_filter)
 
@@ -275,20 +275,20 @@ async def test_list_user_details_by_filter(user_api, user_service):
         skip=0,
         limit=50,
         payload=user_filter,
-        session_token='session_token'
+        session_token="session_token"
     )
 
     assert len(user_detail_list) == 3
-    assert user_detail_list[0].user_attributes.user_name == 'agentservice'
+    assert user_detail_list[0].user_attributes.user_name == "agentservice"
     assert user_detail_list[1].user_system_info.id == 9826885173258
 
 
 @pytest.mark.asyncio
 async def test_list_all_user_details_by_filter(user_api, user_service):
     user_api.v1_admin_user_find_post = AsyncMock()
-    user_api.v1_admin_user_find_post.return_value = get_deserialized_object_from_json('user/list_user_by_filter.json',
+    user_api.v1_admin_user_find_post.return_value = get_deserialized_object_from_json("user/list_user_by_filter.json",
                                                                                       UserDetailList)
-    user_filter = UserFilter(status='ENABLED')
+    user_filter = UserFilter(status="ENABLED")
 
     gen = await user_service.list_all_user_details_by_filter(user_filter)
     user_detail_list = [u async for u in gen]
@@ -297,11 +297,11 @@ async def test_list_all_user_details_by_filter(user_api, user_service):
         skip=0,
         limit=50,
         payload=user_filter,
-        session_token='session_token'
+        session_token="session_token"
     )
 
     assert len(user_detail_list) == 3
-    assert user_detail_list[0].user_attributes.user_name == 'agentservice'
+    assert user_detail_list[0].user_attributes.user_name == "agentservice"
     assert user_detail_list[1].user_system_info.id == 9826885173258
 
 
@@ -319,8 +319,8 @@ async def test_add_role(user_api, user_service):
 
     user_api.v1_admin_user_uid_roles_add_post.assert_called_with(
         uid=1234,
-        payload=StringId(id='INDIVIDUAL'),
-        session_token='session_token'
+        payload=StringId(id="INDIVIDUAL"),
+        session_token="session_token"
     )
 
 
@@ -328,17 +328,17 @@ async def test_add_role(user_api, user_service):
 async def test_list_roles(system_api, user_service):
     system_api.v1_admin_system_roles_list_get = AsyncMock()
     system_api.v1_admin_system_roles_list_get.return_value = \
-        object_from_json_relative_path('user/list_roles.json')
+        object_from_json_relative_path("user/list_roles.json")
 
     role_list = await user_service.list_roles()
 
     system_api.v1_admin_system_roles_list_get.assert_called_with(
-        session_token='session_token'
+        session_token="session_token"
     )
 
     assert len(role_list) == 12
-    assert role_list[0].id == 'CONTENT_MANAGEMENT'
-    assert role_list[1].id == 'COMPLIANCE_OFFICER'
+    assert role_list[0].id == "CONTENT_MANAGEMENT"
+    assert role_list[1].id == "COMPLIANCE_OFFICER"
 
 
 @pytest.mark.asyncio
@@ -355,8 +355,8 @@ async def test_remove_role(user_api, user_service):
 
     user_api.v1_admin_user_uid_roles_remove_post.assert_called_with(
         uid=1234,
-        payload=StringId(id='INDIVIDUAL'),
-        session_token='session_token'
+        payload=StringId(id="INDIVIDUAL"),
+        session_token="session_token"
     )
 
 
@@ -364,18 +364,18 @@ async def test_remove_role(user_api, user_service):
 async def test_get_avatar(user_api, user_service):
     user_api.v1_admin_user_uid_avatar_get = AsyncMock()
     user_api.v1_admin_user_uid_avatar_get.return_value = \
-        object_from_json_relative_path('user/list_avatar.json')
+        object_from_json_relative_path("user/list_avatar.json")
 
     avatar_list = await user_service.get_avatar(1234)
 
     user_api.v1_admin_user_uid_avatar_get.assert_called_with(
         uid=1234,
-        session_token='session_token'
+        session_token="session_token"
     )
 
     assert len(avatar_list) == 5
-    assert avatar_list[0].size == '600'
-    assert avatar_list[1].url == '../avatars/acme/150/7215545057281/3gXMhglCCTwLPL9JAprnyHzYn5-PR49-wYDG814n1g8.png'
+    assert avatar_list[0].size == "600"
+    assert avatar_list[1].url == "../avatars/acme/150/7215545057281/3gXMhglCCTwLPL9JAprnyHzYn5-PR49-wYDG814n1g8.png"
 
 
 @pytest.mark.asyncio
@@ -388,21 +388,21 @@ async def test_update_avatar(user_api, user_service):
         '}'
     )
 
-    await user_service.update_avatar(1234, 'image_string')
+    await user_service.update_avatar(1234, "image_string")
     user_api.v1_admin_user_uid_avatar_update_post.assert_called_with(
         uid=1234,
-        payload=AvatarUpdate(image='image_string'),
-        session_token='session_token'
+        payload=AvatarUpdate(image="image_string"),
+        session_token="session_token"
     )
 
-    with open(get_resource_filepath('user/FINOS_icon_rgb.png', as_text=True), 'rb') as file:
+    with open(get_resource_filepath("user/FINOS_icon_rgb.png", as_text=True), "rb") as file:
         avatar_bytes = file.read()
         await user_service.update_avatar(1234, avatar_bytes)
 
         user_api.v1_admin_user_uid_avatar_update_post.assert_called_with(
             uid=1234,
             payload=AvatarUpdate(image=str(base64.standard_b64encode(avatar_bytes))),
-            session_token='session_token'
+            session_token="session_token"
         )
 
 
@@ -426,11 +426,11 @@ async def test_get_disclaimer(user_api, user_service):
 
     user_api.v1_admin_user_uid_disclaimer_get.assert_called_with(
         uid=1234,
-        session_token='session_token'
+        session_token="session_token"
     )
 
-    assert disclaimer.id == '571d2052e4b042aaf06d2e7a'
-    assert disclaimer.name == 'Enterprise Disclaimer'
+    assert disclaimer.id == "571d2052e4b042aaf06d2e7a"
+    assert disclaimer.name == "Enterprise Disclaimer"
 
 
 @pytest.mark.asyncio
@@ -447,7 +447,7 @@ async def test_remove_disclaimer(user_api, user_service):
 
     user_api.v1_admin_user_uid_disclaimer_delete.assert_called_with(
         uid=1234,
-        session_token='session_token'
+        session_token="session_token"
     )
 
 
@@ -461,12 +461,12 @@ async def test_add_disclaimer(user_api, user_service):
         '}'
     )
 
-    await user_service.add_disclaimer(1234, 'disclaimer_id')
+    await user_service.add_disclaimer(1234, "disclaimer_id")
 
     user_api.v1_admin_user_uid_disclaimer_update_post.assert_called_with(
         uid=1234,
-        payload=StringId(id='disclaimer_id'),
-        session_token='session_token'
+        payload=StringId(id="disclaimer_id"),
+        session_token="session_token"
     )
 
 
@@ -483,7 +483,7 @@ async def test_get_delegates(user_api, user_service):
 
     user_api.v1_admin_user_uid_delegates_get.assert_called_with(
         uid=1234,
-        session_token='session_token'
+        session_token="session_token"
     )
 
     assert len(delegate_list) == 1
@@ -505,7 +505,7 @@ async def test_update_delegates(user_api, user_service):
     user_api.v1_admin_user_uid_delegates_update_post.assert_called_with(
         uid=7215545078541,
         payload=DelegateAction(user_id=7215545078461, action=DelegateActionEnum.ADD.value),
-        session_token='session_token'
+        session_token="session_token"
     )
 
 
@@ -530,11 +530,11 @@ async def test_get_feature_entitlements(user_api, user_service):
 
     user_api.v1_admin_user_uid_features_get.assert_called_with(
         uid=1234,
-        session_token='session_token'
+        session_token="session_token"
     )
 
     assert len(feature_list) == 2
-    assert feature_list[0].entitlment == 'canCreatePublicRoom'
+    assert feature_list[0].entitlment == "canCreatePublicRoom"
     assert not feature_list[1].enabled
 
 
@@ -547,13 +547,13 @@ async def test_update_feature_entitlements(user_api, user_service):
         '   "message": "OK"'
         '}'
     )
-    feature = Feature(entitlment='canCreatePublicRoom', enabled=True)
+    feature = Feature(entitlment="canCreatePublicRoom", enabled=True)
     await user_service.update_feature_entitlements(1234, [feature])
 
     user_api.v1_admin_user_uid_features_update_post.assert_called_with(
         uid=1234,
         payload=FeatureList(value=[feature]),
-        session_token='session_token'
+        session_token="session_token"
     )
 
 
@@ -570,10 +570,10 @@ async def test_get_status(user_api, user_service):
 
     user_api.v1_admin_user_uid_status_get.assert_called_with(
         uid=1234,
-        session_token='session_token'
+        session_token="session_token"
     )
 
-    assert status.status == 'ENABLED'
+    assert status.status == "ENABLED"
 
 
 @pytest.mark.asyncio
@@ -584,28 +584,28 @@ async def test_update_status(user_api, user_service):
         '   "message": "OK"'
         '}'
     )
-    status = UserStatus(status='ENABLED')
+    status = UserStatus(status="ENABLED")
 
     await user_service.update_status(1234, status)
 
     user_api.v1_admin_user_uid_status_update_post.assert_called_with(
         uid=1234,
         payload=status,
-        session_token='session_token'
+        session_token="session_token"
     )
 
 
 @pytest.mark.asyncio
 async def test_list_user_followers(user_api, user_service):
     user_api.v1_user_uid_followers_get = AsyncMock()
-    user_api.v1_user_uid_followers_get.return_value = object_from_json_relative_path('user/list_user_followers.json')
+    user_api.v1_user_uid_followers_get.return_value = object_from_json_relative_path("user/list_user_followers.json")
 
     follower_list = await user_service.list_user_followers(1234, before=4, after=1)
 
     user_api.v1_user_uid_followers_get.assert_called_with(
         uid=1234,
         limit=100,
-        session_token='session_token',
+        session_token="session_token",
         before=4,
         after=1
     )
@@ -618,7 +618,7 @@ async def test_list_user_followers(user_api, user_service):
 @pytest.mark.asyncio
 async def test_list_all_user_followers(user_api, user_service):
     user_api.v1_user_uid_followers_get = AsyncMock()
-    user_api.v1_user_uid_followers_get.return_value = object_from_json_relative_path('user/list_user_followers.json')
+    user_api.v1_user_uid_followers_get.return_value = object_from_json_relative_path("user/list_user_followers.json")
 
     gen = await user_service.list_all_user_followers(1234, max_number=2)
     follower_list = [uid async for uid in gen]
@@ -626,7 +626,7 @@ async def test_list_all_user_followers(user_api, user_service):
     user_api.v1_user_uid_followers_get.assert_called_with(
         uid=1234,
         limit=100,
-        session_token='session_token',
+        session_token="session_token",
     )
 
     assert len(follower_list) == 2
@@ -637,14 +637,14 @@ async def test_list_all_user_followers(user_api, user_service):
 @pytest.mark.asyncio
 async def test_list_users_following(user_api, user_service):
     user_api.v1_user_uid_following_get = AsyncMock()
-    user_api.v1_user_uid_following_get.return_value = object_from_json_relative_path('user/list_users_following.json')
+    user_api.v1_user_uid_following_get.return_value = object_from_json_relative_path("user/list_users_following.json")
 
     following_user_list = await user_service.list_users_following(1234, before=4, after=1)
 
     user_api.v1_user_uid_following_get.assert_called_with(
         uid=1234,
         limit=100,
-        session_token='session_token',
+        session_token="session_token",
         before=4,
         after=1
     )
@@ -657,7 +657,7 @@ async def test_list_users_following(user_api, user_service):
 @pytest.mark.asyncio
 async def test_list_all_users_following(user_api, user_service):
     user_api.v1_user_uid_following_get = AsyncMock()
-    user_api.v1_user_uid_following_get.return_value = object_from_json_relative_path('user/list_users_following.json')
+    user_api.v1_user_uid_following_get.return_value = object_from_json_relative_path("user/list_users_following.json")
 
     gen = await user_service.list_all_users_following(1234, max_number=2)
     following_user_list = [uid async for uid in gen]
@@ -665,7 +665,7 @@ async def test_list_all_users_following(user_api, user_service):
     user_api.v1_user_uid_following_get.assert_called_with(
         uid=1234,
         limit=100,
-        session_token='session_token'
+        session_token="session_token"
     )
 
     assert len(following_user_list) == 2
@@ -676,25 +676,25 @@ async def test_list_all_users_following(user_api, user_service):
 @pytest.mark.asyncio
 async def test_create(user_api, user_service):
     user_api.v2_admin_user_create_post = AsyncMock()
-    user_api.v2_admin_user_create_post.return_value = object_from_json_relative_path('user/user_detail.json')
+    user_api.v2_admin_user_create_post.return_value = object_from_json_relative_path("user/user_detail.json")
 
     user_create = V2UserCreate()
     user_detail = await user_service.create(user_create)
 
     user_api.v2_admin_user_create_post.assert_called_with(
         payload=user_create,
-        session_token='session_token'
+        session_token="session_token"
     )
 
-    assert user_detail.userAttributes.userName == 'johndoe'
-    assert user_detail.userSystemInfo.status == 'ENABLED'
+    assert user_detail.userAttributes.userName == "johndoe"
+    assert user_detail.userSystemInfo.status == "ENABLED"
     assert len(user_detail.roles) == 6
 
 
 @pytest.mark.asyncio
 async def test_update(user_api, user_service):
     user_api.v2_admin_user_uid_update_post = AsyncMock()
-    user_api.v2_admin_user_uid_update_post.return_value = object_from_json_relative_path('user/user_detail.json')
+    user_api.v2_admin_user_uid_update_post.return_value = object_from_json_relative_path("user/user_detail.json")
 
     user_attribute = V2UserAttributes()
 
@@ -703,11 +703,11 @@ async def test_update(user_api, user_service):
     user_api.v2_admin_user_uid_update_post.assert_called_with(
         uid=1234,
         payload=user_attribute,
-        session_token='session_token'
+        session_token="session_token"
     )
 
-    assert user_detail.userAttributes.userName == 'johndoe'
-    assert user_detail.userSystemInfo.status == 'ENABLED'
+    assert user_detail.userAttributes.userName == "johndoe"
+    assert user_detail.userSystemInfo.status == "ENABLED"
     assert len(user_detail.roles) == 6
 
 
@@ -715,7 +715,7 @@ async def test_update(user_api, user_service):
 async def test_list_audit_trail(audit_trail_api, user_service):
     audit_trail_api.v1_audittrail_privilegeduser_get = AsyncMock()
     audit_trail_api.v1_audittrail_privilegeduser_get.return_value = \
-        object_from_json_relative_path('user/list_audit_trail.json')
+        object_from_json_relative_path("user/list_audit_trail.json")
 
     audit_trail_initiator_list = \
         await user_service.list_audit_trail(1234, 2345, 12345, RoleId.SUPER_ADMINISTRATOR, before=1, after=4)
@@ -724,17 +724,17 @@ async def test_list_audit_trail(audit_trail_api, user_service):
         start_timestamp=1234,
         end_timestamp=2345,
         initiator_id=12345,
-        role='SUPER_ADMINISTRATOR',
+        role="SUPER_ADMINISTRATOR",
         before=1,
         after=4,
         limit=50,
-        session_token='session_token',
-        key_manager_token='km_token'
+        session_token="session_token",
+        key_manager_token="km_token"
     )
 
     assert len(audit_trail_initiator_list.items) == 2
     assert audit_trail_initiator_list.items[0].initiatorId == 1353716993
-    assert audit_trail_initiator_list.items[1].authorizationRoles[0] == 'SUPER_ADMINISTRATOR'
+    assert audit_trail_initiator_list.items[1].authorizationRoles[0] == "SUPER_ADMINISTRATOR"
 
 
 @pytest.mark.asyncio
@@ -747,12 +747,12 @@ async def test_suspend_user(user_api, user_service):
         '}'
     )
 
-    user_suspension = UserSuspension(suspended=True, suspended_until=1601596799999, suspension_reason='testing')
+    user_suspension = UserSuspension(suspended=True, suspended_until=1601596799999, suspension_reason="testing")
 
     await user_service.suspend_user(1234, user_suspension)
 
     user_api.v1_admin_user_user_id_suspension_update_put.assert_called_with(
         user_id=1234,
         payload=user_suspension,
-        session_token='session_token'
+        session_token="session_token"
     )

--- a/tests/core/service_factory_test.py
+++ b/tests/core/service_factory_test.py
@@ -19,7 +19,7 @@ from symphony.bdk.gen import ApiClient
 from tests.utils.resource_utils import get_config_resource_filepath
 
 
-@pytest.fixture(name='api_client_factory')
+@pytest.fixture(name="api_client_factory")
 def fixture_api_client_factory():
     factory = MagicMock(ApiClientFactory)
     api_client = MagicMock(ApiClient)
@@ -28,13 +28,13 @@ def fixture_api_client_factory():
     return factory
 
 
-@pytest.fixture(name='config')
+@pytest.fixture(name="config")
 def fixture_config():
-    config = BdkConfigLoader.load_from_file(get_config_resource_filepath('config.yaml'))
+    config = BdkConfigLoader.load_from_file(get_config_resource_filepath("config.yaml"))
     return config
 
 
-@pytest.fixture(name='service_factory')
+@pytest.fixture(name="service_factory")
 def fixture_service_factory(api_client_factory, config):
     factory = ServiceFactory(api_client_factory, AuthSession(None), config)
     return factory
@@ -81,17 +81,17 @@ def test_get_datafeed_loop(config, service_factory):
     assert datafeed_loop is not None
     assert isinstance(datafeed_loop, DatafeedLoopV1)
 
-    config.datafeed.version = 'v1'
+    config.datafeed.version = "v1"
     datafeed_loop = service_factory.get_datafeed_loop()
     assert datafeed_loop is not None
     assert isinstance(datafeed_loop, DatafeedLoopV1)
 
-    config.datafeed.version = 'something'
+    config.datafeed.version = "something"
     datafeed_loop = service_factory.get_datafeed_loop()
     assert datafeed_loop is not None
     assert isinstance(datafeed_loop, DatafeedLoopV1)
 
-    config.datafeed.version = 'v2'
+    config.datafeed.version = "v2"
     datafeed_loop = service_factory.get_datafeed_loop()
     assert datafeed_loop is not None
     assert isinstance(datafeed_loop, DatafeedLoopV2)

--- a/tests/core/service_factory_test.py
+++ b/tests/core/service_factory_test.py
@@ -10,6 +10,7 @@ from symphony.bdk.core.service.connection.connection_service import ConnectionSe
 from symphony.bdk.core.service.datafeed.datafeed_loop_v1 import DatafeedLoopV1
 from symphony.bdk.core.service.datafeed.datafeed_loop_v2 import DatafeedLoopV2
 from symphony.bdk.core.service.message.message_service import MessageService
+from symphony.bdk.core.service.presence.presence_service import PresenceService
 from symphony.bdk.core.service.signal.signal_service import SignalService
 from symphony.bdk.core.service.stream.stream_service import StreamService
 from symphony.bdk.core.service.user.user_service import UserService
@@ -18,8 +19,8 @@ from symphony.bdk.gen import ApiClient
 from tests.utils.resource_utils import get_config_resource_filepath
 
 
-@pytest.fixture()
-def api_client_factory():
+@pytest.fixture(name='api_client_factory')
+def fixture_api_client_factory():
     factory = MagicMock(ApiClientFactory)
     api_client = MagicMock(ApiClient)
     factory.get_pod_client.return_value = api_client
@@ -27,14 +28,14 @@ def api_client_factory():
     return factory
 
 
-@pytest.fixture()
-def config():
-    config = BdkConfigLoader.load_from_file(get_config_resource_filepath("config.yaml"))
+@pytest.fixture(name='config')
+def fixture_config():
+    config = BdkConfigLoader.load_from_file(get_config_resource_filepath('config.yaml'))
     return config
 
 
-@pytest.fixture()
-def service_factory(api_client_factory, config):
+@pytest.fixture(name='service_factory')
+def fixture_service_factory(api_client_factory, config):
     factory = ServiceFactory(api_client_factory, AuthSession(None), config)
     return factory
 
@@ -42,55 +43,61 @@ def service_factory(api_client_factory, config):
 def test_get_user_service(service_factory):
     user_service = service_factory.get_user_service()
     assert user_service is not None
-    assert type(user_service) == UserService
+    assert isinstance(user_service, UserService)
 
 
 def test_get_message_service(service_factory):
     message_service = service_factory.get_message_service()
     assert message_service is not None
-    assert type(message_service) == MessageService
+    assert isinstance(message_service, MessageService)
 
 
 def test_get_connection_service(service_factory):
     connection_service = service_factory.get_connection_service()
     assert connection_service is not None
-    assert type(connection_service) == ConnectionService
+    assert isinstance(connection_service, ConnectionService)
 
 
 def test_get_stream_service(service_factory):
     stream_service = service_factory.get_stream_service()
     assert stream_service is not None
-    assert type(stream_service) == StreamService
+    assert isinstance(stream_service, StreamService)
 
 
 def test_get_application_service(service_factory):
     application_service = service_factory.get_application_service()
     assert application_service is not None
-    assert type(application_service) == ApplicationService
+    assert isinstance(application_service, ApplicationService)
 
 
 def test_get_signal_service(service_factory):
     signal_service = service_factory.get_signal_service()
     assert signal_service is not None
-    assert type(signal_service) == SignalService
+    assert isinstance(signal_service, SignalService)
 
 
 def test_get_datafeed_loop(config, service_factory):
     datafeed_loop = service_factory.get_datafeed_loop()
     assert datafeed_loop is not None
-    assert type(datafeed_loop) == DatafeedLoopV1
+    assert isinstance(datafeed_loop, DatafeedLoopV1)
 
-    config.datafeed.version = "v1"
+    config.datafeed.version = 'v1'
     datafeed_loop = service_factory.get_datafeed_loop()
     assert datafeed_loop is not None
-    assert type(datafeed_loop) == DatafeedLoopV1
+    assert isinstance(datafeed_loop, DatafeedLoopV1)
 
-    config.datafeed.version = "something"
+    config.datafeed.version = 'something'
     datafeed_loop = service_factory.get_datafeed_loop()
     assert datafeed_loop is not None
-    assert type(datafeed_loop) == DatafeedLoopV1
+    assert isinstance(datafeed_loop, DatafeedLoopV1)
 
-    config.datafeed.version = "v2"
+    config.datafeed.version = 'v2'
     datafeed_loop = service_factory.get_datafeed_loop()
     assert datafeed_loop is not None
-    assert type(datafeed_loop) == DatafeedLoopV2
+    assert isinstance(datafeed_loop, DatafeedLoopV2)
+
+
+def test_get_presence_service(service_factory):
+    presence_service = service_factory.get_presence_service()
+    assert presence_service is not None
+    assert isinstance(presence_service, PresenceService)

--- a/tests/core/symphony_bdk_test.py
+++ b/tests/core/symphony_bdk_test.py
@@ -14,43 +14,43 @@ from symphony.bdk.core.symphony_bdk import SymphonyBdk
 from tests.utils.resource_utils import get_config_resource_filepath
 
 
-@pytest.fixture(name='config')
+@pytest.fixture(name="config")
 def fixture_config():
-    return BdkConfigLoader.load_from_file(get_config_resource_filepath('config.yaml'))
+    return BdkConfigLoader.load_from_file(get_config_resource_filepath("config.yaml"))
 
 
-@pytest.fixture(name='obo_only_config')
+@pytest.fixture(name="obo_only_config")
 def fixture_obo_only_config():
-    return BdkConfig(host='acme.symphony.com', app={'appId': 'app', 'privateKey': {'path': '/path/to/key.pem'}})
+    return BdkConfig(host="acme.symphony.com", app={"appId": "app", "privateKey": {"path": "/path/to/key.pem"}})
 
 
-@pytest.fixture(name='mock_obo_session')
+@pytest.fixture(name="mock_obo_session")
 def fixture_mock_obo_session():
     obo_session = AsyncMock(OboAuthSession)
-    obo_session.session_token.return_value = 'session_token'
-    obo_session.key_manager_token.return_value = ''
+    obo_session.session_token.return_value = "session_token"
+    obo_session.key_manager_token.return_value = ""
 
     return obo_session
 
 
 @pytest.mark.asyncio
 async def test_bot_session(config):
-    with patch('symphony.bdk.core.auth.bot_authenticator.create_signed_jwt', return_value='privateKey'):
+    with patch("symphony.bdk.core.auth.bot_authenticator.create_signed_jwt", return_value="privateKey"):
         bot_authenticator = AsyncMock(BotAuthenticatorRsa)
-        bot_authenticator.retrieve_session_token.return_value = 'session_token'
-        bot_authenticator.retrieve_key_manager_token.return_value = 'km_token'
+        bot_authenticator.retrieve_session_token.return_value = "session_token"
+        bot_authenticator.retrieve_key_manager_token.return_value = "km_token"
         bot_session = AuthSession(bot_authenticator)
         async with SymphonyBdk(config) as symphony_bdk:
             symphony_bdk._bot_session = bot_session
             auth_session = symphony_bdk.bot_session()
             assert auth_session is not None
-            assert await auth_session.session_token == 'session_token'
-            assert await auth_session.key_manager_token == 'km_token'
+            assert await auth_session.session_token == "session_token"
+            assert await auth_session.key_manager_token == "km_token"
 
 
 @pytest.mark.asyncio
 async def test_obo_with_user_id(config):
-    with patch.object(OboAuthenticatorRsa, 'authenticate_by_user_id') as mock_authenticate:
+    with patch.object(OboAuthenticatorRsa, "authenticate_by_user_id") as mock_authenticate:
         mock_authenticate.return_value = Mock(OboAuthSession)
         user_id = 12345
 
@@ -63,9 +63,9 @@ async def test_obo_with_user_id(config):
 
 @pytest.mark.asyncio
 async def test_obo_with_username(config):
-    with patch.object(OboAuthenticatorRsa, 'authenticate_by_username') as mock_authenticate:
+    with patch.object(OboAuthenticatorRsa, "authenticate_by_username") as mock_authenticate:
         mock_authenticate.return_value = Mock(OboAuthSession)
-        username = 'my.bot.user'
+        username = "my.bot.user"
 
         async with SymphonyBdk(config) as symphony_bdk:
             obo_session = symphony_bdk.obo(username=username)
@@ -76,13 +76,13 @@ async def test_obo_with_username(config):
 
 @pytest.mark.asyncio
 async def test_obo_with_user_id_and_username(config):
-    with patch.object(OboAuthenticatorRsa, 'authenticate_by_username') as authenticate_by_username, \
-            patch.object(OboAuthenticatorRsa, 'authenticate_by_user_id') as authenticate_by_user_id:
+    with patch.object(OboAuthenticatorRsa, "authenticate_by_username") as authenticate_by_username, \
+            patch.object(OboAuthenticatorRsa, "authenticate_by_user_id") as authenticate_by_user_id:
         authenticate_by_user_id.return_value = Mock(OboAuthSession)
         user_id = 12345
 
         async with SymphonyBdk(config) as symphony_bdk:
-            obo_session = symphony_bdk.obo(user_id=user_id, username='bot.user')
+            obo_session = symphony_bdk.obo(user_id=user_id, username="bot.user")
 
             assert obo_session is not None
             authenticate_by_user_id.assert_called_once_with(user_id)

--- a/tests/core/symphony_bdk_test.py
+++ b/tests/core/symphony_bdk_test.py
@@ -14,43 +14,43 @@ from symphony.bdk.core.symphony_bdk import SymphonyBdk
 from tests.utils.resource_utils import get_config_resource_filepath
 
 
-@pytest.fixture()
-def config():
-    return BdkConfigLoader.load_from_file(get_config_resource_filepath("config.yaml"))
+@pytest.fixture(name='config')
+def fixture_config():
+    return BdkConfigLoader.load_from_file(get_config_resource_filepath('config.yaml'))
 
 
-@pytest.fixture()
-def obo_only_config():
-    return BdkConfig(host="acme.symphony.com", app={"appId": "app", "privateKey": {"path": "/path/to/key.pem"}})
+@pytest.fixture(name='obo_only_config')
+def fixture_obo_only_config():
+    return BdkConfig(host='acme.symphony.com', app={'appId': 'app', 'privateKey': {'path': '/path/to/key.pem'}})
 
 
-@pytest.fixture()
-def mock_obo_session():
+@pytest.fixture(name='mock_obo_session')
+def fixture_mock_obo_session():
     obo_session = AsyncMock(OboAuthSession)
-    obo_session.session_token.return_value = "session_token"
-    obo_session.key_manager_token.return_value = ""
+    obo_session.session_token.return_value = 'session_token'
+    obo_session.key_manager_token.return_value = ''
 
     return obo_session
 
 
 @pytest.mark.asyncio
 async def test_bot_session(config):
-    with patch("symphony.bdk.core.auth.bot_authenticator.create_signed_jwt", return_value="privateKey"):
+    with patch('symphony.bdk.core.auth.bot_authenticator.create_signed_jwt', return_value='privateKey'):
         bot_authenticator = AsyncMock(BotAuthenticatorRsa)
-        bot_authenticator.retrieve_session_token.return_value = "session_token"
-        bot_authenticator.retrieve_key_manager_token.return_value = "km_token"
+        bot_authenticator.retrieve_session_token.return_value = 'session_token'
+        bot_authenticator.retrieve_key_manager_token.return_value = 'km_token'
         bot_session = AuthSession(bot_authenticator)
         async with SymphonyBdk(config) as symphony_bdk:
             symphony_bdk._bot_session = bot_session
             auth_session = symphony_bdk.bot_session()
             assert auth_session is not None
-            assert await auth_session.session_token == "session_token"
-            assert await auth_session.key_manager_token == "km_token"
+            assert await auth_session.session_token == 'session_token'
+            assert await auth_session.key_manager_token == 'km_token'
 
 
 @pytest.mark.asyncio
 async def test_obo_with_user_id(config):
-    with patch.object(OboAuthenticatorRsa, "authenticate_by_user_id") as mock_authenticate:
+    with patch.object(OboAuthenticatorRsa, 'authenticate_by_user_id') as mock_authenticate:
         mock_authenticate.return_value = Mock(OboAuthSession)
         user_id = 12345
 
@@ -63,9 +63,9 @@ async def test_obo_with_user_id(config):
 
 @pytest.mark.asyncio
 async def test_obo_with_username(config):
-    with patch.object(OboAuthenticatorRsa, "authenticate_by_username") as mock_authenticate:
+    with patch.object(OboAuthenticatorRsa, 'authenticate_by_username') as mock_authenticate:
         mock_authenticate.return_value = Mock(OboAuthSession)
-        username = "my.bot.user"
+        username = 'my.bot.user'
 
         async with SymphonyBdk(config) as symphony_bdk:
             obo_session = symphony_bdk.obo(username=username)
@@ -76,13 +76,13 @@ async def test_obo_with_username(config):
 
 @pytest.mark.asyncio
 async def test_obo_with_user_id_and_username(config):
-    with patch.object(OboAuthenticatorRsa, "authenticate_by_username") as authenticate_by_username, \
-            patch.object(OboAuthenticatorRsa, "authenticate_by_user_id") as authenticate_by_user_id:
+    with patch.object(OboAuthenticatorRsa, 'authenticate_by_username') as authenticate_by_username, \
+            patch.object(OboAuthenticatorRsa, 'authenticate_by_user_id') as authenticate_by_user_id:
         authenticate_by_user_id.return_value = Mock(OboAuthSession)
         user_id = 12345
 
         async with SymphonyBdk(config) as symphony_bdk:
-            obo_session = symphony_bdk.obo(user_id=user_id, username="bot.user")
+            obo_session = symphony_bdk.obo(user_id=user_id, username='bot.user')
 
             assert obo_session is not None
             authenticate_by_user_id.assert_called_once_with(user_id)

--- a/tests/utils/resource_utils.py
+++ b/tests/utils/resource_utils.py
@@ -8,7 +8,7 @@ from symphony.bdk.gen.rest import RESTResponse
 
 
 def get_resource_filepath(relative_path, as_text=True):
-    resources_path = Path(__file__).parent / '../resources'
+    resources_path = Path(__file__).parent / "../resources"
     resource_path = resources_path / relative_path
     if as_text:
         return str(resource_path.resolve())
@@ -28,7 +28,7 @@ def object_from_json_relative_path(relative_path):
 
 
 def get_deserialized_object_from_json(relative_path, return_type):
-    resp = namedtuple('MockResp', ['status', 'reason'])(200, '')
+    resp = namedtuple("MockResp", ["status", "reason"])(200, "")
     rest_resp = RESTResponse(resp, get_resource_content(relative_path))
 
     return ApiClient().deserialize(rest_resp, (return_type,), True)
@@ -40,6 +40,6 @@ def get_config_resource_filepath(relative_path):
     :param relative_path: str relative path of the resources at "test/resources/"
     :return: the absolute path of the specified resource
     """
-    resources_path = Path(__file__).parent / '../resources/config'
+    resources_path = Path(__file__).parent / "../resources/config"
     resource_path = resources_path / relative_path
     return str(resource_path.resolve())

--- a/tests/utils/resource_utils.py
+++ b/tests/utils/resource_utils.py
@@ -8,12 +8,11 @@ from symphony.bdk.gen.rest import RESTResponse
 
 
 def get_resource_filepath(relative_path, as_text=True):
-    resources_path = Path(__file__).parent / "../resources"
+    resources_path = Path(__file__).parent / '../resources'
     resource_path = resources_path / relative_path
     if as_text:
         return str(resource_path.resolve())
-    else:
-        return resource_path.resolve()
+    return resource_path.resolve()
 
 
 def get_resource_content(relative_path):
@@ -29,7 +28,7 @@ def object_from_json_relative_path(relative_path):
 
 
 def get_deserialized_object_from_json(relative_path, return_type):
-    resp = namedtuple('MockResp', ['status', 'reason'])(200, "")
+    resp = namedtuple('MockResp', ['status', 'reason'])(200, '')
     rest_resp = RESTResponse(resp, get_resource_content(relative_path))
 
     return ApiClient().deserialize(rest_resp, (return_type,), True)
@@ -41,6 +40,6 @@ def get_config_resource_filepath(relative_path):
     :param relative_path: str relative path of the resources at "test/resources/"
     :return: the absolute path of the specified resource
     """
-    resources_path = Path(__file__).parent / "../resources/config"
+    resources_path = Path(__file__).parent / '../resources/config'
     resource_path = resources_path / relative_path
     return str(resource_path.resolve())


### PR DESCRIPTION
### Ticket
[PLAT-10600](https://perzoinc.atlassian.net/browse/PLAT-10600)

### Description
Goal of this PR is to enable pylint checks in the PR builder.
For now the limit to fail is set to 9.70 (max being 10.00). We can start like this and if needed we can adapt it later on if we think that is too strict.

### Checklist
- [x] Referenced a ticket in the PR title and in the corresponding section
- [x] Filled properly the description and dependencies, if any
- [x] Unit tests updated or added
- [x] Docstrings added or updated
- [x] Updated the documentation in [docs folder](../docs)
